### PR TITLE
Add assume form to cancel tests if conditions fail

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -104,6 +104,20 @@ This is the mechanism underlying `expect'. You can use it
 directly if you want to write your own testing functionality."
   (signal 'buttercup-failed (apply #'format format args)))
 
+(defun buttercup-skip (format &rest args)
+  "Skip the current test with the given description."
+  (signal 'buttercup-pending (apply #'format format args)))
+
+(defmacro assume (condition &optional message)
+  "Assume CONDITIION for the current test.
+
+Assume that CONDITION evaluates to non-nil in the current test.
+If it evaluates to nil cancel the current test with MESSAGE.  If
+MESSAGE is omitted or nil show the condition form instead."
+  (let ((message (or message (format "%S => nil" condition))))
+    `(unless ,condition
+       (buttercup-skip "!! CANCELLED !! %s" ,message))))
+
 (defmacro buttercup-define-matcher (matcher args &rest body)
   "Define a matcher to be used in `expect'.
 

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -103,6 +103,31 @@
             :to-throw
             'buttercup-failed "Explanation")))
 
+(describe "The `assume' form"
+  (it "should raise a signal if the condition is nil"
+    (expect (lambda ()
+              (assume nil "Explanation"))
+            :to-throw
+            'buttercup-pending "!! CANCELLED !! Explanation"))
+
+  (it "should show the format if no message is given"
+    (expect (lambda ()
+              (assume (< 1 0)))
+            :to-throw
+            'buttercup-pending "!! CANCELLED !! (< 1 0) => nil"))
+
+  (it "should not raise a signal if the condition is non-nil"
+    (expect (lambda ()
+              (assume 'non-nil "Explanation"))
+            :not :to-throw)))
+
+(describe "The `buttercup-skip function"
+  (it "should raise a signal with its arguments"
+    (expect (lambda ()
+              (buttercup-skip "Explanation" ))
+            :to-throw
+            'buttercup-pending "Explanation")))
+
 (buttercup-define-matcher :test-matcher (a b)
   (+ a b))
 


### PR DESCRIPTION
The assume form cancels the current test if the given condition is not met.  It is intended to be used in tests that depend on a certain global state that might not be present, e.g. a tool in `exec-path` or a network connection, etc.

Example:

```cl
(describe "Eggs"
  (it "gets eggs from the internet"
    (assume (network-available-p) "No network connection")
    (my/get-eggs)))
```

Output if the assumption is not met

```
Eggs
  gets eggs from the internet  !! CANCELLED !! No network connection
```