### PR TITLE
Added: integration with undercover.el

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -659,6 +659,7 @@ current directory."
         (push (car args) dirs)
         (setq args (cdr args)))))
     (setq command-line-args-left nil)
+    (when (require 'undercover nil t) (undercover))
     (dolist (dir (or dirs '(".")))
       (dolist (file (directory-files-recursively
                      dir "\\`test-.*\\.el\\'\\|-test\\.el\\'"))


### PR DESCRIPTION
This PR is related to #9.

It shows how to integrate `emacs-buttercup` with `undercover.el`.

Consider simple case when user has project that uses `emacs-buttercup` for testing. And user want to collect test coverage information for all his top-level `*.el` files (I think it's most common case). To do so user can simply add `(depends-on "undercover")` to `Cask` file. See the [experimenting](https://github.com/sviridov/undercover.el-buttercup-integration-example/tree/experimenting) branch of [undercover.el-buttercup-integration-example](https://github.com/sviridov/undercover.el-buttercup-integration-example/tree/experimenting) as an example.

If user will want to provide extra configuration to `undercover.el` (exclude some files, etc.) user can do it with [UNDERCOVER_CONFIG](https://github.com/sviridov/undercover.el#configuration) environment variable and do something like this:

``` sh
UNDERCOVER_CONFIG='("*.el" (:exclude "awesome-examples.el"))' cask exec buttercup -L .
```

So, what do you think about it?

P.S. While experimenting with `undercover.el-buttercup-integration-example` I faced one strange error when I added `underover` to existed `Cask` file (and `.cask` directory) and did `cask install`:

``` sh
$ cask install
$ TRAVIS=true cask exec buttercup -L . # TRAVIS=true will force undercover to run.

> Invalid function: undercover

$ rm -Rf .cask/
$ cask install
$ TRAVIS=true cask exec buttercup -L .

> Successful output
```

Not sure why that happens. 
