### PR TITLE
Add :to-equal-as-set to compare lists as sets.

### DIFF
--- a/buttercup-compat.el
+++ b/buttercup-compat.el
@@ -35,6 +35,9 @@
 (when (not (fboundp 'cl-defstruct))
   (defalias 'cl-defstruct 'defstruct))
 
+(when (not (fboundp 'cl-every))
+  (defalias 'cl-every 'every))
+
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Introduced in 24.4
 

--- a/buttercup.el
+++ b/buttercup.el
@@ -161,6 +161,11 @@ MATCHER is either a matcher defined with
       (cons t (format "Expected %S not to `equal' %S" a b))
     (cons nil (format "Expected %S to `equal' %S" a b))))
 
+(buttercup-define-matcher :to-have-same-items-as (a b)
+  (if (cl-every (lambda (x) (member x b)) a)
+      (cons t (format "Expected %S not to have same items as %S" a b))
+    (cons nil (format "Expected %S to have same items as %S" a b))))
+
 (buttercup-define-matcher :to-match (text regexp)
   (if (string-match regexp text)
       (cons t (format "Expected %S not to match the regexp %S"

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -103,6 +103,15 @@ that are not included below.
             (bar '((a . 12) (b . 34))))
         (expect foo :to-equal bar))))
 
+  (it "The :to-have-same-items-as matcher compares two lists as sets"
+    (let ((first (list "a" "b" "c"))
+          (second (list "c" "a" "b"))
+          (third (list "a" "c" "d")))
+      (expect first :to-have-same-items-as second)
+      (expect second :to-have-same-items-as first)
+      (expect first :not :to-have-same-items-as third)
+      (expect third :not :to-have-same-items-as second)))
+
   (it "The :to-match matcher is for regular expressions"
     (let ((message "foo bar baz"))
       (expect message :to-match "bar")


### PR DESCRIPTION
Since lists often double as sets in lisp, a primitive to compare them as such is rather useful.

I'm currently writing some "query language parser" to select based on tags (e.g `"foo+bar|baz+!quo"`) and I don't quite care about the order so long as the set returned is correct.

So this simply adds a matcher to do that :P