### PR TITLE
bin/buttercup: support more emacs parameters useful for pre-test initialization

### DIFF
--- a/bin/buttercup
+++ b/bin/buttercup
@@ -13,7 +13,7 @@ BUTTERCUP_ARGS=()
 while [[ "$#" -gt 0 ]]
 do
     case "$1" in
-        "-L")
+        "-L"|"--directory"|"-f"|"--funcall"|"-l"|"--load"|"--eval"|"--execute")
             EMACS_ARGS+=("$1")
             EMACS_ARGS+=("$2")
             shift


### PR DESCRIPTION
This PR adds support for other pre-test initialization parameters besides `-L`, such as `-f`, `-l` and `--eval` and their long variants.