### PR TITLE
Exclude hidden files and dirs in test root

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -683,7 +683,7 @@ current directory."
     (dolist (dir (or dirs '(".")))
       (dolist (file (directory-files-recursively
                      dir "\\`test-.*\\.el\\'\\|-tests?\\.el\\'"))
-        (when (not (string-match "/\\." (file-relative-name file)))
+        (when (not (string-match "\\(^\\|/\\)\\." (file-relative-name file)))
           (load file nil t))))
     (when patterns
       (let ((suites-or-specs buttercup-suites))


### PR DESCRIPTION
The `bin/buttercup` shell script should not try to run tests in hidden
subdirectories of the working directory.  In particular, it should not
run tests found in the `.pc/` directory that quilt(1) generates.