### PR TITLE
Report load errors in buttercup-run-discover

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -684,7 +684,10 @@ current directory."
       (dolist (file (directory-files-recursively
                      dir "\\`test-.*\\.el\\'\\|-tests?\\.el\\'"))
         (when (not (string-match "\\(^\\|/\\)\\." (file-relative-name file)))
-          (load file nil t))))
+          (condition-case err
+              (load file nil t)
+            (error
+             (message (format "Error while loading %s:\n%s" file (error-message-string err))))))))
     (when patterns
       (let ((suites-or-specs buttercup-suites))
         (while suites-or-specs


### PR DESCRIPTION
Previously file load errors were uncaught resulting in the core error message being printed, but without any context.  In a project with many test files a syntax error may be nearly untenable.

This change reports the error message with the name of the file as context and then resumes loading test files and running the test suite.