### PR TITLE
Colorize output

### DIFF
--- a/bin/buttercup
+++ b/bin/buttercup
@@ -25,6 +25,10 @@ do
             shift
             shift
             ;;
+        "-c"|"--no-color")
+            BUTTERCUP_ARGS+=("$1")
+            shift
+            ;;
         *)
             BUTTERCUP_ARGS+=("$1")
             shift


### PR DESCRIPTION
As penance for submitting the #10 issue for the third time, I thought I'd take a stab at implementing it.

![selection_037](https://cloud.githubusercontent.com/assets/229422/23582097/1f8920e8-0123-11e7-87a7-358f541a7a17.png)

The implementation is was slightly complicated by the fact that the reporter needs to print the text of the spec again on completion, in order to add the color. It could probably be improved much by refactoring it and the standard reporter.

I haven't implemented any detection of color support. I looked at Ecukes for inspiration, and it seems to me that it always uses colors. I've implemented a kill-switch though.
