### PR TITLE
note dependency on Emacs 24+

### DIFF
--- a/buttercup-pkg.el
+++ b/buttercup-pkg.el
@@ -1,2 +1,3 @@
 (define-package "buttercup" "1.5"
+  '((emacs "24"))
   "Behavior-Driven Emacs Lisp Testing")

--- a/buttercup.el
+++ b/buttercup.el
@@ -4,6 +4,7 @@
 
 ;; Version: 1.5
 ;; Author: Jorgen Schaefer <contact@jorgenschaefer.de>
+;; Package-Requires: ((emacs "24"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License


### PR DESCRIPTION
Required due to the use of pcase, which was added in https://github.com/emacs-mirror/emacs/commit/d02c9bcd096c44b4e3d5e2834c75967b56cdecdd