### PR TITLE
[Fix #72] Add buttercup-minor-mode

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -1109,5 +1109,29 @@ failed -- The second value is the description of the expectation
             frame (backtrace-frame n)))
     frame-list))
 
+;;;###autoload
+(define-minor-mode buttercup-minor-mode
+  "Activate buttercup minor mode.
+
+With buttercup minor mode active the following is activated:
+
+- `describe' and `it' forms are fontified with
+  `font-lock-keyword-face'.
+- `describe' and `it' forms are available from `imenu' for
+  quicker access."
+  :lighter " ❀"
+  (let ((font-lock-form '(("(\\(describe\\|buttercup-define-matcher\\|it\\) "
+                           1 'font-lock-keyword-face)))
+        (imenu-forms '(("Test Suites" "\\((describe\\_> +\\)\"\\(\\_<.+\\_>\\)\"" 2)
+                       ("Spec" "\\((it\\_> +\\)\"\\(\\_<.+\\_>\\)\"" 2))))
+    (if buttercup-minor-mode
+        (progn
+          (font-lock-add-keywords nil font-lock-form)
+          (cl-dolist (form imenu-forms)
+            (add-to-list 'imenu-generic-expression form)))
+      (font-lock-remove-keywords nil font-lock-form)
+      (cl-dolist (form imenu-forms)
+        (setq imenu-generic-expression (delete form imenu-generic-expression))))))
+
 (provide 'buttercup)
 ;;; buttercup.el ends here

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -730,3 +730,46 @@
     (error "Expected erroring buttercup--funcall not to return %S"
            res)))
 
+;;;;;;;;;;;;;
+;;; Buttercup-minor-mode
+
+(describe "butter-minor-mode"
+
+  (it "should fontify `describe' special form"
+    (with-temp-buffer
+      (emacs-lisp-mode)
+      (buttercup-minor-mode 1)
+      (font-lock-mode)
+      (insert "(describe \"A test suite\" (it \"should fontify special keywords\"))")
+      (font-lock-fontify-region (point-min) (point-max))
+      (expect
+       (text-property-any (point-min) (point-max) 'face 'font-lock-keyword-face)
+       :to-equal 2)))
+
+  (it "should fontify `it' special form"
+    (with-temp-buffer
+      (emacs-lisp-mode)
+      (buttercup-minor-mode 1)
+      (font-lock-mode)
+      (insert "(describe \"A test suite\" (it \"should fontify special keywords\"))")
+      (font-lock-fontify-region (point-min) (point-max))
+      (expect
+       (text-property-any 15 (point-max) 'face 'font-lock-keyword-face)
+       :to-equal 27)))
+
+  (it "should add special forms to `imenu'"
+    (with-temp-buffer
+      (require 'imenu)
+      (emacs-lisp-mode)
+      (buttercup-minor-mode 1)
+      (insert "(describe \"A test suite\"
+  (it \"should fontify special keywords\"))")
+      (imenu--make-index-alist)
+      (let ((suites (assoc "Test Suites" imenu--index-alist))
+            (specs (assoc "Spec" imenu--index-alist)))
+        (expect suites :to-be-truthy)
+        (expect (length (cdr suites)) :to-equal 1)
+        (expect (caadr suites) :to-equal "A test suite")
+        (expect specs :to-be-truthy)
+        (expect (length (cdr specs)) :to-equal 1)
+        (expect (caadr specs) :to-equal "should fontify special keywords")))))


### PR DESCRIPTION
With buttercup minor mode active the following is activated:

- `describe` and `it` forms are fontified with
  `font-lock-keyword-face`.
- `describe` and `it` forms are available from `imenu` for
  quicker access.