### PR TITLE
Fix :to-have-same-items-as  (fix #80)

### DIFF
--- a/buttercup-compat.el
+++ b/buttercup-compat.el
@@ -38,6 +38,9 @@
 (when (not (fboundp 'cl-every))
   (defalias 'cl-every 'every))
 
+(when (not (fboundp 'cl-subsetp))
+  (defalias 'cl-subsetp 'subsetp))
+
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Introduced in 24.4
 

--- a/buttercup.el
+++ b/buttercup.el
@@ -162,7 +162,8 @@ MATCHER is either a matcher defined with
     (cons nil (format "Expected %S to `equal' %S" a b))))
 
 (buttercup-define-matcher :to-have-same-items-as (a b)
-  (if (cl-every (lambda (x) (member x b)) a)
+  (if (and (cl-subsetp a b :test #'equal)
+           (cl-subsetp b a :test #'equal))
       (cons t (format "Expected %S not to have same items as %S" a b))
     (cons nil (format "Expected %S to have same items as %S" a b))))
 

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -106,11 +106,14 @@ that are not included below.
   (it "The :to-have-same-items-as matcher compares two lists as sets"
     (let ((first (list "a" "b" "c"))
           (second (list "c" "a" "b"))
-          (third (list "a" "c" "d")))
+          (third (list "a" "c" "d"))
+          (fourth (list "a" "b")))
       (expect first :to-have-same-items-as second)
       (expect second :to-have-same-items-as first)
       (expect first :not :to-have-same-items-as third)
-      (expect third :not :to-have-same-items-as second)))
+      (expect third :not :to-have-same-items-as second)
+      (expect first :not :to-have-same-items-as fourth)
+      (expect fourth :not :to-have-same-items-as first)))
 
   (it "The :to-match matcher is for regular expressions"
     (let ((message "foo bar baz"))


### PR DESCRIPTION
This fixes #80 by adapting `:to-have-same-items-as` implementation to what I think the name suggests.