### PR TITLE
Print unevaluated expression when reporting a failure

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -246,7 +246,8 @@ MATCHER is either a matcher defined with
                                  "of %S, but it threw %S")
                          function signal (car err)))))
       (t
-       (cons t (format "Expected %S not to throw an error" function)))))))
+       (cons t (format "Expected %S not to throw an error, but it threw %S"
+                       function err)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Suite and spec data structures

--- a/buttercup.el
+++ b/buttercup.el
@@ -67,13 +67,14 @@ This macro knows three forms:
   Fail the current test iff ARG is not true."
   (cond
    ((and (not matcher)
-         (consp arg))
+         (consp arg)
+         (consp (cdr arg))
+         (consp (cddr arg)))
     `(buttercup-expect ,(cadr arg)
                        #',(car arg)
                        (list ,@(cddr arg))
                        ',arg))
-   ((and (not matcher)
-         (not (consp arg)))
+   ((and (not matcher))
     `(buttercup-expect ,arg nil nil ',arg))
    (t
     `(buttercup-expect ,arg ,matcher (list ,@args) ',arg))))

--- a/buttercup.el
+++ b/buttercup.el
@@ -83,10 +83,16 @@ This macro knows three forms:
   "The function for the `expect' macro.
 
 See the macro documentation for details."
-  (let ((prefix
-         (if orig-expr
-             (format "While evaluating `%S': " orig-expr)
-           "")))
+  (let* ((oneline-prefix
+          (if orig-expr
+              (format "While evaluating `%S': " orig-expr)
+            ""))
+         (prefix
+          (if (< (length oneline-prefix) 60)
+              oneline-prefix
+            (format "While evaluating\n%s"
+                    (replace-regexp-in-string "^\\(.\\)" "    \\1"
+                                              (pp-to-string orig-expr))))))
     (if (not matcher)
         (when (not arg)
           (buttercup-fail "%sExpected %S to be non-nil" prefix arg))

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -41,17 +41,17 @@
   (it "with a matcher should translate directly to the function call"
     (expect (macroexpand '(expect (+ 1 1) :to-equal 2))
             :to-equal
-            '(buttercup-expect (+ 1 1) :to-equal 2)))
+            '(buttercup-expect (+ 1 1) :to-equal (list 2) '(+ 1 1))))
 
   (it "with a form argument should extract the matcher from the form"
     (expect (macroexpand '(expect (equal (+ 1 1) 2)))
             :to-equal
-            '(buttercup-expect (+ 1 1) #'equal 2)))
+            '(buttercup-expect (+ 1 1) #'equal (list 2) '(equal (+ 1 1) 2))))
 
   (it "with a single argument should pass it to the function"
     (expect (macroexpand '(expect t))
             :to-equal
-            '(buttercup-expect t))))
+            '(buttercup-expect t nil nil 't))))
 
 (describe "The `buttercup-expect' function"
   (describe "with a single argument"
@@ -71,13 +71,13 @@
   (describe "with a function as a matcher argument"
     (it "should not raise an error if the function returns true"
       (expect (lambda ()
-                (buttercup-expect t #'eq t))
+                (buttercup-expect t #'eq '(t)))
               :not :to-throw
               'buttercup-failed))
 
     (it "should raise an error if the function returns false"
       (expect (lambda ()
-                (buttercup-expect t #'eq nil))
+                (buttercup-expect t #'eq '(nil)))
               :to-throw
               'buttercup-failed)))
 


### PR DESCRIPTION
The `expect` macro now passes `args` as a single list to `buttercup-expect` (instead of as the `&rest` arguments), and then passes a 4th argument which is the unevaluated expression that was passed to `expect`. `buttercup-expect` uses this to add a prefix to the failure message containing the unevaluated expression. This solution is kind of clunky, but requires no changes to existing matchers. With this change, now `(expect (+ 1 1) :to-equal 3)` fails with ``While evaluating `(+ 1 1)': Expected 2 to `equal' 3``.

The tests for the macro expansion of `expect` have been modified accordingly.