### PR TITLE
Reimplement "spy-on" to work with commands

### DIFF
--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -505,7 +505,10 @@
 
 (describe "The Spy "
   (let (test-function)
-    (before-each
+    ;; We use `before-all' here because some tests need to access the
+    ;; same function as previous tests in order to work, so overriding
+    ;; the function before each test would invalidate those tests.
+    (before-all
       (fset 'test-function (lambda (a b)
                              (+ a b))))
 


### PR DESCRIPTION
The new implementation preserves the interactive form of its argument,
and warns if the replacement passed to :and-call-fake changes the
interactive form. This ensures that spied commands can still be called
as commands (i.e. via "command-execute").

I haven't added any tests for this yet.