### PR TITLE
Ensure elc files are up to date before running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
 EMACS := emacs
-VERSION = $(shell sed -ne 's/^;; Version: \(.*\)/\1/p' buttercup.el)
-DISTFILES = buttercup.el buttercup-compat.el buttercup-pkg.el README.md
+VERSION := $(shell sed -ne 's/^;; Version: \(.*\)/\1/p' buttercup.el)
+ELISP_FILES := $(shell ls *.el | grep -v -- '-pkg\.el$$')
+DISTFILES := $(ELISP_FILES) buttercup-pkg.el README.md
 
-
-.PHONY: test
+.PHONY: test compile clean
 
 all: test
 
-test:
+test: compile
 	$(EMACS) -batch -L . -l buttercup.el -f buttercup-run-markdown docs/writing-tests.md
 	./bin/buttercup -L .
 
-compile:
-	$(EMACS) -batch -L . -f batch-byte-compile *.el
+compile: $(patsubst %.el,%.elc,$(ELISP_FILES))
+
+%.elc: %.el
+	$(EMACS) -batch -L . -f batch-byte-compile $<
 
 release: clean test
 	mkdir -p dist


### PR DESCRIPTION
The test rule in the Makefile now depends on the compile rule, so
there should be no more warnings about out-of-date elc files when
running tests.