### PR TITLE
Signal an error when ":to-throw" is used on a non-function

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -203,6 +203,10 @@ MATCHER is either a matcher defined with
                       a b precision))))
 
 (buttercup-define-matcher :to-throw (function &optional signal signal-args)
+  ;; This will trigger errors relating to FUNCTION not being a
+  ;; function outside the following `condition-case'.
+  (when (not (functionp function))
+    (funcall function))
   (condition-case err
       (progn
         (funcall function)

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -165,7 +165,12 @@ that are not included below.
       (let ((foo (lambda () (+ a 1)))
             (bar (lambda () (+ a 1))))
         (expect foo :not :to-throw 'void-variable '(b))
-        (expect bar :to-throw 'void-variable '(a))))))
+        (expect bar :to-throw 'void-variable '(a))))
+    (it "only works on functions"
+      (expect (lambda () (expect nil :to-throw 'error))
+              :to-throw 'void-function)
+      (expect (lambda () (expect "hello" :not :to-throw 'error))
+              :to-throw 'invalid-function))))
 ```
 
 ## Grouping Related Specs with `describe`


### PR DESCRIPTION
Comes with a test.

Fixes #53.
