### PR TITLE
Set failure description to empty string for pending specs

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -930,7 +930,9 @@ A disabled spec is not run."
   (let ((spec (car (last (buttercup-suite-children
                           buttercup--current-suite)))))
     (setf (buttercup-spec-status spec)
-          'pending)))
+          'pending
+          (buttercup-spec-failure-description spec)
+          "")))
 
 ;;;;;;;;;
 ;;; Spies


### PR DESCRIPTION
Removes the nils from this writing-tests.md testcase

Pending specs
  can be declared using `xit'  nil
  can be declared with `it' but without a body  nil