### PR TITLE
Simplifications based on a super-struct for suite and spec

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -693,19 +693,11 @@ See also `buttercup-define-matcher'."
 
 (defun buttercup-suites-total-specs-defined (suite-list)
   "Return the number of specs defined in all suites in SUITE-LIST."
-  (let ((nspecs 0))
-    (dolist (spec-or-suite (buttercup--specs-and-suites suite-list))
-      (when (buttercup-spec-p spec-or-suite)
-        (setq nspecs (1+ nspecs))))
-    nspecs))
+  (length (buttercup--specs suite-list)))
 
 (defun buttercup-suites-total-specs-status (suite-list status)
   "Return the number of specs in SUITE-LIST marked with STATUS."
-  (let ((nspecs 0))
-    (dolist (spec-or-suite (buttercup--specs-and-suites suite-list) nspecs)
-      (when (and (buttercup-spec-p spec-or-suite)
-                 (eq (buttercup-spec-status spec-or-suite) status))
-        (setq nspecs (1+ nspecs))))))
+  (cl-count status (buttercup--specs suite-list) :key #'buttercup-spec-status))
 
 (defun buttercup-suites-total-specs-pending (suite-list)
   "Return the number of specs marked as pending in all suites in SUITE-LIST."
@@ -754,8 +746,7 @@ See also `buttercup-define-matcher'."
 (defun buttercup--full-spec-names (spec-or-suite-list)
   "Return full names of all specs in SPEC-OR-SUITE-LIST."
   (cl-loop
-   for x in (buttercup--specs-and-suites spec-or-suite-list)
-   if (buttercup-spec-p x)
+   for x in (buttercup--specs spec-or-suite-list)
    collect (buttercup-spec-full-name x)))
 
 (defun buttercup--find-duplicate-spec-names (spec-or-suite-list)

--- a/buttercup.el
+++ b/buttercup.el
@@ -730,11 +730,9 @@ See also `buttercup-define-matcher'."
 
 (defun buttercup-suite-full-name (suite)
   "Return the full name of SUITE, which includes the names of the parents."
-  (let ((name-parts (mapcar #'buttercup-suite-description
-                            (cons suite (buttercup-suite-parents suite)))))
-    (mapconcat #'identity
-               (reverse name-parts)
-               " ")))
+  (mapconcat #'buttercup-suite-description
+             (nreverse (cons suite (buttercup-suite-parents suite)))
+             " "))
 
 (defun buttercup-spec-full-name (spec)
   "Return the full name of SPEC, which includes the full name of its suite."

--- a/buttercup.el
+++ b/buttercup.el
@@ -715,6 +715,15 @@ See also `buttercup-define-matcher'."
   "Return the number of failed specs in all suites in SUITE-LIST."
   (buttercup-suites-total-specs-status suite-list 'failed))
 
+(defun buttercup--specs (spec-or-suite-list)
+  "Return a flat list of all specs in SPEC-OR-SUITE-LIST."
+  (let (specs)
+    (dolist (spec-or-suite spec-or-suite-list specs)
+      (if (buttercup-spec-p spec-or-suite)
+          (setq specs (append specs (list spec-or-suite)))
+        (setq specs (append specs (buttercup--specs
+                                   (buttercup-suite-children spec-or-suite))))))))
+
 (defun buttercup--specs-and-suites (spec-or-suite-list)
   "Return a flat list of all specs and suites in SPEC-OR-SUITE-LIST."
   (let ((specs-and-suites nil))

--- a/buttercup.el
+++ b/buttercup.el
@@ -1187,21 +1187,13 @@ current directory."
         (when (not (string-match "\\(^\\|/\\)\\." (file-relative-name file)))
           (load file nil t))))
     (when patterns
-      (let ((suites-or-specs buttercup-suites))
-        (while suites-or-specs
-          (cond
-           ((buttercup-suite-p (car suites-or-specs))
-            (setq suites-or-specs (append suites-or-specs
-                                          (buttercup-suite-children
-                                           (car suites-or-specs)))))
-           ((buttercup-spec-p (car suites-or-specs))
-            (catch 'return
-              (dolist (p patterns)
-                (when (string-match p (buttercup-spec-full-name (car suites-or-specs)))
-                  (throw 'return t)))
-              (setf (buttercup-spec-function (car suites-or-specs))
-                    (lambda () (signal 'buttercup-pending "SKIPPED"))))))
-          (setq suites-or-specs (cdr suites-or-specs)))))
+      (dolist (spec (buttercup--specs buttercup-suites))
+        (let ((spec-full-name (buttercup-spec-full-name spec)))
+          (unless (cl-dolist (p patterns)
+                    (when (string-match p spec-full-name)
+                      (cl-return t)))
+            (setf (buttercup-spec-function spec)
+                  (lambda () (signal 'buttercup-pending "SKIPPED")))))))
     (buttercup-run)))
 
 ;;;###autoload

--- a/buttercup.el
+++ b/buttercup.el
@@ -649,37 +649,31 @@ See also `buttercup-define-matcher'."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Suite and spec data structures
 
-(cl-defstruct buttercup-suite
+(cl-defstruct buttercup-suite-or-spec
   ;; The name of this specific suite
   description
-  ;; Any children of this suite, both suites and specs
-  children
   ;; The parent of this suite, another suite
   parent
+  ;; One of: passed failed pending
+  (status 'passed)
+  failure-description
+  failure-stack
+  )
+
+(cl-defstruct (buttercup-suite (:include buttercup-suite-or-spec))
+  ;; Any children of this suite, both suites and specs
+  children
   ;; Closure to run before and after each spec in this suite and its
   ;; children
   before-each
   after-each
   ;; Likewise, but before and after all specs.
   before-all
-  after-all
-  ;; These are set if there are errors in after-all.
-  ;; One of: passed failed pending
-  (status 'passed)
-  failure-description
-  failure-stack)
+  after-all)
 
-(cl-defstruct buttercup-spec
-  ;; The description of the it form this was generated from
-  description
-  ;; The suite this spec is a member of
-  parent
+(cl-defstruct (buttercup-spec (:include buttercup-suite-or-spec))
   ;; The closure to run for this spec
-  function
-  ;; One of: passed failed pending
-  (status 'passed)
-  failure-description
-  failure-stack)
+  function)
 
 (defun buttercup-suite-add-child (parent child)
   "Add a CHILD suite to a PARENT suite."

--- a/buttercup.el
+++ b/buttercup.el
@@ -680,25 +680,16 @@ See also `buttercup-define-matcher'."
   (setf (buttercup-suite-children parent)
         (append (buttercup-suite-children parent)
                 (list child)))
-  (if (buttercup-suite-p child)
-      (setf (buttercup-suite-parent child)
-            parent)
-    (setf (buttercup-spec-parent child)
-          parent)))
+  (setf (buttercup-suite-or-spec-parent child) parent))
 
-(defun buttercup-suite-parents (suite)
-  "Return a list of parents of SUITE."
-  (if (buttercup-suite-parent suite)
-      (cons (buttercup-suite-parent suite)
-            (buttercup-suite-parents (buttercup-suite-parent suite)))
-    nil))
+(defun buttercup-suite-or-spec-parents (suite-or-spec)
+  "Return a list of parents of SUITE-OR-SPEC."
+  (when (buttercup-suite-or-spec-parent suite-or-spec)
+    (cons (buttercup-suite-or-spec-parent suite-or-spec)
+          (buttercup-suite-or-spec-parents (buttercup-suite-or-spec-parent suite-or-spec)))))
 
-(defun buttercup-spec-parents (spec)
-  "Return a list of parents of SPEC."
-  (if (buttercup-spec-parent spec)
-      (cons (buttercup-spec-parent spec)
-            (buttercup-suite-parents (buttercup-spec-parent spec)))
-    nil))
+(define-obsolete-function-alias 'buttercup-suite-parents 'buttercup-suite-or-spec-parents "emacs-buttercup 1.10")
+(define-obsolete-function-alias 'buttercup-spec-parents 'buttercup-suite-or-spec-parents "emacs-buttercup 1.10")
 
 (defun buttercup-suites-total-specs-defined (suite-list)
   "Return the number of specs defined in all suites in SUITE-LIST."

--- a/buttercup.el
+++ b/buttercup.el
@@ -716,17 +716,16 @@ See also `buttercup-define-matcher'."
   (buttercup-suites-total-specs-status suite-list 'failed))
 
 (defun buttercup--specs-and-suites (spec-or-suite-list)
-  "Return the number of specs defined in SPEC-OR-SUITE-LIST and its children."
+  "Return a flat list of all specs and suites in SPEC-OR-SUITE-LIST."
   (let ((specs-and-suites nil))
-    (dolist (spec-or-suite spec-or-suite-list)
+    (dolist (spec-or-suite spec-or-suite-list specs-and-suites)
       (setq specs-and-suites (append specs-and-suites
                                      (list spec-or-suite)))
       (when (buttercup-suite-p spec-or-suite)
         (setq specs-and-suites
               (append specs-and-suites
                       (buttercup--specs-and-suites
-                       (buttercup-suite-children spec-or-suite))))))
-    specs-and-suites))
+                       (buttercup-suite-children spec-or-suite))))))))
 
 (defun buttercup-suite-full-name (suite)
   "Return the full name of SUITE, which includes the names of the parents."

--- a/buttercup.el
+++ b/buttercup.el
@@ -1299,19 +1299,11 @@ Do not change the global value.")
         (`(error (buttercup-pending . ,pending-description))
          (setq status 'pending
                description pending-description))))
-    (cond
-     ((buttercup-suite-p suite-or-spec)
-      (when (eq (buttercup-suite-status suite-or-spec)
-                'passed)
-        (setf (buttercup-suite-status suite-or-spec) status)
-        (setf (buttercup-suite-failure-description suite-or-spec) description)
-        (setf (buttercup-suite-failure-stack suite-or-spec) stack)))
-     (t
-      (when (eq (buttercup-spec-status suite-or-spec)
-                'passed)
-        (setf (buttercup-spec-status suite-or-spec) status)
-        (setf (buttercup-spec-failure-description suite-or-spec) description)
-        (setf (buttercup-spec-failure-stack suite-or-spec) stack))))))
+    (when (eq (buttercup-suite-or-spec-status suite-or-spec)
+              'passed)
+      (setf (buttercup-suite-or-spec-status suite-or-spec) status
+            (buttercup-suite-or-spec-failure-description suite-or-spec) description
+            (buttercup-suite-or-spec-failure-stack suite-or-spec) stack))))
 
 ;;;;;;;;;;;;;
 ;;; Reporters


### PR DESCRIPTION
Extracted a super struct buttercup-suite-or-spec from buttercup-suite and buttercup-spec, and then used it to simplify code and increase reuse.