### PR TITLE
Change shebang to use /usr/bin/env

### DIFF
--- a/bin/buttercup
+++ b/bin/buttercup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n "$INSIDE_EMACS" ]
 then


### PR DESCRIPTION
Not all systems provides a /bin/bash (even GNU/Linux based systems!), but /usr/bin/env is present on pretty much all systems that I can think of.

For example: I'm on NixOS. NixOS places everything that matters in other places than `/bin` and `/usr/bin`. The only path within `/bin` on my system is `/bin/sh` which is a symlink. And the only path within `/usr` on my system is `/usr/bin/env` which (surprise surprise) is also a symlink to `/nix/...somewhere...`