### PR TITLE
Set failure-description for pending specs

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -1394,6 +1394,9 @@ Do not change the global value.")
       (kill-buffer buttercup-warning-buffer-name))))
 
 (defun buttercup--update-with-funcall (suite-or-spec function &rest args)
+  "Update SUITE-OR-SPEC with the result of calling FUNCTION with ARGS.
+Sets the `status', `failure-description', and `failure-stack' for
+failed and pending specs."
   (let* ((result (apply 'buttercup--funcall function args))
          (status (elt result 0))
          (description (elt result 1))
@@ -1405,8 +1408,8 @@ Do not change the global value.")
         (`(error (buttercup-pending . ,pending-description))
          (setq status 'pending
                description pending-description))))
-    (when (eq (buttercup-suite-or-spec-status suite-or-spec)
-              'passed)
+    (when (memq (buttercup-suite-or-spec-status suite-or-spec)
+                '(passed pending))
       (setf (buttercup-suite-or-spec-status suite-or-spec) status
             (buttercup-suite-or-spec-failure-description suite-or-spec) description
             (buttercup-suite-or-spec-failure-stack suite-or-spec) stack))))

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -530,7 +530,15 @@
       (expect (buttercup-spec-status
                (car (last (buttercup-suite-children
                            buttercup--current-suite))))
-              :to-be 'pending))))
+              :to-be 'pending)))
+
+  (it "should set the failure description to PENDING"
+    (let ((buttercup--current-suite (make-buttercup-suite))
+          spec)
+      (buttercup-xit "bla bla")
+      (setq spec (car (buttercup-suite-children buttercup--current-suite)))
+      (buttercup--update-with-funcall spec (buttercup-spec-function spec))
+      (expect (buttercup-suite-or-spec-failure-description spec) :to-equal "PENDING"))))
 
 ;;;;;;;;;
 ;;; Spies
@@ -852,6 +860,15 @@
           (buttercup-reporter-batch 'spec-done spec))
 
         (expect 'buttercup--print :to-have-been-called-with "  FAILED\n"))
+
+      (it "should output the failure-description for a pending spec"
+        (setf (buttercup-spec-status spec) 'pending
+              (buttercup-spec-failure-description spec) "DESCRIPTION")
+        (let ((buttercup-reporter-batch--failures nil))
+          (buttercup-reporter-batch 'spec-done spec))
+        (expect (mapconcat (apply-partially #'apply #'format)
+                           (spy-calls-all-args 'buttercup--print) "")
+                :to-match "DESCRIPTION"))
 
       (it "should throw an error for an unknown spec status"
         (setf (buttercup-spec-status spec) 'unknown)


### PR DESCRIPTION
The status slot in buttercup-suite-or-spec is set ahead of time for
pending (not skipped) specs.  This meant that the failure-description
and failure-stack of pending specs were never set in
buttercup--update-with-funcall.  This in turn meant that the output of
pending specs was

    a pending spec

rather than

    a pending spec  PENDING

which it should have been.

The failure-stack will still always be nil for pending specs.