### PR TITLE
Timed specs

### DIFF
--- a/buttercup-compat.el
+++ b/buttercup-compat.el
@@ -91,5 +91,24 @@ If INCLUDE-DIRECTORIES, also include directories that have matching names."
     (and (> (length name) 0)
          (char-equal (aref name (1- (length name))) ?/))))
 
+(when (not (fboundp 'seconds-to-string))
+  (defvar seconds-to-string
+	(list (list 1 "ms" 0.001)
+          (list 100 "s" 1)
+          (list (* 60 100) "m" 60.0)
+          (list (* 3600 30) "h" 3600.0)
+          (list (* 3600 24 400) "d" (* 3600.0 24.0))
+          (list nil "y" (* 365.25 24 3600)))
+	"Formatting used by the function `seconds-to-string'.")
+  (defun seconds-to-string (delay)
+	"Convert the time interval in seconds to a short string."
+	(cond ((> 0 delay) (concat "-" (seconds-to-string (- delay))))
+          ((= 0 delay) "0s")
+          (t (let ((sts seconds-to-string) here)
+               (while (and (car (setq here (pop sts)))
+                           (<= (car here) delay)))
+               (concat (format "%.2f" (/ delay (car (cddr here)))) (cadr here)))))))
+
+
 (provide 'buttercup-compat)
 ;;; buttercup-compat.el ends here

--- a/buttercup.el
+++ b/buttercup.el
@@ -919,7 +919,7 @@ FUNCTION is a function containing the body instructions passed to
   "Process FORMS to make any suites or specs pending."
   (when (eq (car forms) :var)
     (setq forms (cddr forms)))
-  (let (retained inner)
+  (let (retained)
     (dolist (form forms (nreverse retained))
       (pcase form
         ;; Make it pending by just keeping the description

--- a/buttercup.el
+++ b/buttercup.el
@@ -1488,17 +1488,19 @@ EVENT and ARG are described in `buttercup-reporter'."
 
       (`spec-done
        (cond
-        ((eq (buttercup-spec-status arg) 'passed)
-         (buttercup--print "\n"))
+        ((eq (buttercup-spec-status arg) 'passed)) ; do nothing
         ((eq (buttercup-spec-status arg) 'failed)
-         (buttercup--print "  FAILED\n")
+         (buttercup--print "  FAILED")
          (setq buttercup-reporter-batch--failures
                (append buttercup-reporter-batch--failures
                        (list arg))))
         ((eq (buttercup-spec-status arg) 'pending)
-         (buttercup--print "  %s\n" (buttercup-spec-failure-description arg)))
+         (buttercup--print "  %s" (buttercup-spec-failure-description arg)))
         (t
-         (error "Unknown spec status %s" (buttercup-spec-status arg)))))
+         (error "Unknown spec status %s" (buttercup-spec-status arg))))
+       (buttercup--print " (%s)\n"
+                         (seconds-to-string
+                          (float-time (buttercup-elapsed-time arg)))))
 
       (`suite-done
        (when (= 0 (length (buttercup-suite-or-spec-parents arg)))
@@ -1559,11 +1561,11 @@ EVENT and ARG are described in `buttercup-reporter'."
      (let ((level (length (buttercup-suite-or-spec-parents arg))))
        (cond
         ((eq (buttercup-spec-status arg) 'passed)
-         (buttercup--print (buttercup-colorize "\r%s%s\n" 'green)
+         (buttercup--print (buttercup-colorize "\r%s%s" 'green)
                            (make-string (* 2 level) ?\s)
                            (buttercup-spec-description arg)))
         ((eq (buttercup-spec-status arg) 'failed)
-         (buttercup--print (buttercup-colorize "\r%s%s  FAILED\n" 'red)
+         (buttercup--print (buttercup-colorize "\r%s%s  FAILED" 'red)
                            (make-string (* 2 level) ?\s)
                            (buttercup-spec-description arg))
          (setq buttercup-reporter-batch--failures
@@ -1571,13 +1573,16 @@ EVENT and ARG are described in `buttercup-reporter'."
                        (list arg))))
         ((eq (buttercup-spec-status arg) 'pending)
          (if (equal (buttercup-spec-failure-description arg) "SKIPPED")
-             (buttercup--print "  %s\n" (buttercup-spec-failure-description arg))
-           (buttercup--print (buttercup-colorize "\r%s%s  %s\n" 'yellow)
+             (buttercup--print "  %s" (buttercup-spec-failure-description arg))
+           (buttercup--print (buttercup-colorize "\r%s%s  %s" 'yellow)
                              (make-string (* 2 level) ?\s)
                              (buttercup-spec-description arg)
                              (buttercup-spec-failure-description arg))))
         (t
-         (error "Unknown spec status %s" (buttercup-spec-status arg))))))
+         (error "Unknown spec status %s" (buttercup-spec-status arg))))
+       (buttercup--print " (%s)\n"
+                         (seconds-to-string
+                          (float-time (buttercup-elapsed-time arg))))))
 
     (`buttercup-done
      (dolist (failed buttercup-reporter-batch--failures)


### PR DESCRIPTION
The "Print elapsed time for each spec" commit is a demonstration of what can be done with the timestamps added in the commit before. The elapsed time output may need some more formatting.