### PR TITLE
Move return code

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -1350,7 +1350,9 @@ A suite must be defined within a Markdown \"lisp\" code block."
       (progn
         (funcall buttercup-reporter 'buttercup-started buttercup-suites)
         (mapc #'buttercup--run-suite buttercup-suites)
-        (funcall buttercup-reporter 'buttercup-done buttercup-suites))
+        (funcall buttercup-reporter 'buttercup-done buttercup-suites)
+        (when (> (buttercup-suites-total-specs-failed buttercup-suites) 0)
+          (error "")))
     (error "No suites defined")))
 
 (defvar buttercup--before-each nil
@@ -1542,9 +1544,7 @@ EVENT and ARG are described in `buttercup-reporter'."
            (buttercup--print "Ran %s specs, %s failed, in %.1f seconds.\n"
                              defined
                              failed
-                             duration))
-         (when (> failed 0)
-           (error ""))))
+                             duration))))
 
       (_
        (error "Unknown event %s" event)))))
@@ -1628,9 +1628,7 @@ EVENT and ARG are described in `buttercup-reporter'."
            ", in %.1f seconds.\n")
           defined
           failed
-          duration))
-       (when (> failed 0)
-         (error ""))))
+          duration))))
 
     (_
      ;; Fall through to buttercup-reporter-batch implementation.

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -979,11 +979,11 @@
       (it "should handle the end event"
         (buttercup-reporter-batch 'buttercup-done nil))
 
-      (it "should raise an error if at least one spec failed"
+      (it "should not raise any error even if a spec failed"
         (setf (buttercup-spec-status spec) 'failed)
 
         (expect (buttercup-reporter-batch 'buttercup-done (list spec))
-                :to-throw)))
+                :not :to-throw)))
 
     (describe "on an unknown event"
       (it "should raise an error"
@@ -1006,6 +1006,10 @@
       (buttercup-suite-add-child child-suite spec)
       (spy-on 'reporter)
       (spy-on 'runner))
+    (it "should raise an error if at least one spec failed"
+      (setf (buttercup-spec-status spec) 'failed)
+      (cl-letf (((symbol-function 'buttercup--run-suite) #'ignore))
+        (expect (buttercup-run) :to-throw)))
     (it "should call the reporter twice with events buttercup-started and -done"
       (cl-letf (((symbol-function 'buttercup--run-suite) #'ignore))
         (expect (buttercup-run) :not :to-throw)


### PR DESCRIPTION
The reporter should not contain anything that affects the running of
the tests.  Setting buttercup-reporter to 'ignore should just produce
no output.  It shall be possible to chain two reporters without
exiting when the first reporter reaches buttercup-done.