### PR TITLE
Do not leak functions from "The Spy " suite

### DIFF
--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -613,16 +613,27 @@
 ;;; Spies
 
 (describe "The Spy "
-  (let (test-function)
+  (let (saved-test-function saved-test-command)
     ;; We use `before-all' here because some tests need to access the
     ;; same function as previous tests in order to work, so overriding
     ;; the function before each test would invalidate those tests.
     (before-all
+      (setq saved-test-function (and (fboundp 'test-function)
+                                     (symbol-function 'test-function))
+            saved-test-command (and (fboundp 'test-command)
+                                    (symbol-function 'test-command)))
       (fset 'test-function (lambda (a b)
                              (+ a b)))
       (fset 'test-command (lambda ()
                             (interactive)
                             t)))
+    (after-all
+      (if saved-test-function
+          (fset 'test-function saved-test-function)
+        (fmakunbound 'test-function))
+      (if saved-test-command
+          (fset 'test-command saved-test-command)
+        (fmakunbound 'test-command)))
 
     (describe "`spy-on' function"
       (it "replaces a symbol's function slot"


### PR DESCRIPTION
The (symbol-function test-function) cannot be lexically bound, but
equivalent behaviour can be acheived using before-all and after-all.

This is an alternative (better?) solution for 769e7b025549c5e64d011a0ecfe675b48c5eecab in #146. 


#