### PR TITLE
Exclude skipped tests from first report line

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -1368,14 +1368,19 @@ current directory."
         (when (not (string-match "\\(^\\|/\\)\\." (file-relative-name file)))
           (load file nil t))))
     (when patterns
-      (dolist (spec (buttercup--specs buttercup-suites))
-        (let ((spec-full-name (buttercup-spec-full-name spec)))
-          (unless (cl-dolist (p patterns)
-                    (when (string-match p spec-full-name)
-                      (cl-return t)))
-            (setf (buttercup-spec-function spec)
-                  (lambda () (signal 'buttercup-pending "SKIPPED")))))))
+      (buttercup--mark-skipped buttercup-suites patterns))
     (buttercup-run)))
+
+(defun buttercup--mark-skipped (suites patterns)
+  "Mark any spec in SUITES not matching PATTERNS as skipped.
+SUITES is a list of suites. PATTERNS is a list of regexps."
+  (dolist (spec (buttercup--specs suites))
+    (let ((spec-full-name (buttercup-spec-full-name spec)))
+      (unless (cl-dolist (p patterns)
+                (when (string-match p spec-full-name)
+                  (cl-return t)))
+        (setf (buttercup-spec-function spec)
+              (lambda () (signal 'buttercup-pending "SKIPPED")))))))
 
 ;;;###autoload
 (defun buttercup-run-markdown-buffer (&rest markdown-buffers)

--- a/buttercup.el
+++ b/buttercup.el
@@ -1380,7 +1380,8 @@ SUITES is a list of suites. PATTERNS is a list of regexps."
                 (when (string-match p spec-full-name)
                   (cl-return t)))
         (setf (buttercup-spec-function spec)
-              (lambda () (signal 'buttercup-pending "SKIPPED")))))))
+              (lambda () (signal 'buttercup-pending "SKIPPED"))
+              (buttercup-spec-status spec) 'pending)))))
 
 ;;;###autoload
 (defun buttercup-run-markdown-buffer (&rest markdown-buffers)

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -252,6 +252,23 @@
               :to-equal
               2))))
 
+(describe "The `buttercup-suites-total-specs-pending' function"
+  :var (suites)
+  (before-each
+    (with-local-buttercup
+      (describe "first suite"
+        (it "active test" (expect 1 :to-equal 1))
+        (xit "pending test"))
+      (xdescribe "second suite"
+        (it "forced pending" (expect 1 :to-equal 2)))
+      (describe "third suite"
+        (it "potentially skipped" (expect 1 :to-equal 1)))
+      (setq suites buttercup-suites)))
+  (it "should return the number of pending specs in a list of suites"
+    (with-local-buttercup
+      (expect (buttercup-suites-total-specs-pending suites)
+              :to-equal 2))))
+
 (describe "The `buttercup-suites-total-specs-failed' function"
   (it "should return the number of failed specs in a list of suites"
     (let ((su1 (make-buttercup-suite :description "su1"))

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -267,7 +267,12 @@
   (it "should return the number of pending specs in a list of suites"
     (with-local-buttercup
       (expect (buttercup-suites-total-specs-pending suites)
-              :to-equal 2))))
+              :to-equal 2)))
+  (it "should also count skipped specs"
+    (with-local-buttercup
+      (buttercup--mark-skipped suites (list "skipped"))
+      (expect (buttercup-suites-total-specs-pending suites)
+              :to-equal 3))))
 
 (describe "The `buttercup-suites-total-specs-failed' function"
   (it "should return the number of failed specs in a list of suites"


### PR DESCRIPTION
The first line in a report:

```
Running 113 specs.
```

did take pending tests into account, but not tests that were skipped
by the `bin/buttercup` `-p` option.  Setting the spec `status` field
to `pending` will exclude the skipped tests from the "Running" count. 


----

#