### PR TITLE
Change: (buttercup-define-matcher-for-binary-function) Add newlines

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -381,7 +381,17 @@ See also `buttercup-define-matcher'."
             (if explainer
                 ;; %x is the undocumented substitution for the
                 ;; explainer's output
-                "Expected `%A' to be `%f' to `%b', but instead it was `%a' which does not match because: %x."
+                "Expected:
+    `%A'
+
+to be `%f' to:
+    `%b'
+
+but instead it was:
+    `%a'
+
+which does not match because:
+    %x."
               "Expected `%A' to be `%f' to `%b', but instead it was `%a'.")))
     (unless expect-mismatch-phrase
       (setq expect-mismatch-phrase


### PR DESCRIPTION
Add newlines to expect-match-phrase to make output human-readable.

Here's some example output before the change:
```
FAILED: Expected `(org-ql org-ql-test-buffer (not (tags-local
"personal" "world")) :action (org-ql-test-org-get-heading))' to be `equal' to `("Test data" "Take over the universe" "Take over Mars" "Visit Mars"
"Take over the moon" "Visit the moon" "Renew membership in supervillain club" "Learn universal sign language" "Order a pizza" "Internet" "Spaceship
lease" "Fix flux capacitor" "Recurring" "/r/emacs" "Shop for groceries" "Sunrise/sunset" "Ideas" "Rewrite Emacs in Common Lisp" "Write a symphony"
"Code" "Agenda examining" "Agenda censoring" "Auto grouping" "Auto categories" "Date" "Effort" "Misc" "let-plist" "Profiling")', but instead it was
`("Test data" "Take over the universe" "Take over Mars" "Visit Mars" "Take over the moon" "Visit the moon" "Renew membership in supervillain club"
"Learn universal sign language" "Order a pizza" "Internet" "Spaceship lease" "Fix flux capacitor" "Recurring" "/r/emacs" "Shop for groceries"
"Sunrise/sunset" "Ideas" "Rewrite Emacs in Common Lisp" "Write a symphony")' which does not match because: (proper-lists-of-different-length 19 29
("Test data" "Take over the universe" "Take over Mars" "Visit Mars" "Take over the moon" "Visit the moon" "Renew membership in supervillain club"
"Learn universal sign language" "Order a pizza" "Internet" "Spaceship lease" "Fix flux capacitor" "Recurring" "/r/emacs" "Shop for groceries"
"Sunrise/sunset" "Ideas" "Rewrite Emacs in Common Lisp" "Write a symphony") ("Test data" "Take over the universe" "Take over Mars" "Visit Mars" "Take
over the moon" "Visit the moon" "Renew membership in supervillain club" "Learn universal sign language" "Order a pizza" "Internet" "Spaceship lease"
"Fix flux capacitor" "Recurring" "/r/emacs" "Shop for groceries" "Sunrise/sunset" "Ideas" "Rewrite Emacs in Common Lisp" "Write a symphony" "Code"
"Agenda examining" "Agenda censoring" "Auto grouping" "Auto categories" "Date" "Effort" "Misc" "let-plist" "Profiling") first-mismatch-at 19).
```
And after the change:
```
FAILED: Expected:
    `(org-ql org-ql-test-buffer (not (tags-local "personal" "world")) :action (org-ql-test-org-get-heading))'

to be `equal' to:
    `("Test data" "Take over the universe" "Take over Mars" "Visit Mars" "Take over the moon" "Visit the moon" "Renew membership in supervillain club"
"Learn universal sign language" "Order a pizza" "Internet" "Spaceship lease" "Fix flux capacitor" "Recurring" "/r/emacs" "Shop for groceries"
"Sunrise/sunset" "Ideas" "Rewrite Emacs in Common Lisp" "Write a symphony" "Code" "Agenda examining" "Agenda censoring" "Auto grouping" "Auto
categories" "Date" "Effort" "Misc" "let-plist" "Profiling")'

but instead it was:
    `("Test data" "Take over the universe" "Take over Mars" "Visit Mars" "Take over the moon" "Visit the moon" "Renew membership in supervillain club"
"Learn universal sign language" "Order a pizza" "Internet" "Spaceship lease" "Fix flux capacitor" "Recurring" "/r/emacs" "Shop for groceries"
"Sunrise/sunset" "Ideas" "Rewrite Emacs in Common Lisp" "Write a symphony")'

which does not match because:
    (proper-lists-of-different-length 19 29 ("Test data" "Take over the universe" "Take over Mars" "Visit Mars" "Take over the moon" "Visit the moon"
"Renew membership in supervillain club" "Learn universal sign language" "Order a pizza" "Internet" "Spaceship lease" "Fix flux capacitor" "Recurring"
"/r/emacs" "Shop for groceries" "Sunrise/sunset" "Ideas" "Rewrite Emacs in Common Lisp" "Write a symphony") ("Test data" "Take over the universe"
"Take over Mars" "Visit Mars" "Take over the moon" "Visit the moon" "Renew membership in supervillain club" "Learn universal sign language" "Order a
pizza" "Internet" "Spaceship lease" "Fix flux capacitor" "Recurring" "/r/emacs" "Shop for groceries" "Sunrise/sunset" "Ideas" "Rewrite Emacs in Common
Lisp" "Write a symphony" "Code" "Agenda examining" "Agenda censoring" "Auto grouping" "Auto categories" "Date" "Effort" "Misc" "let-plist"
"Profiling") first-mismatch-at 19).
```

As you can see, the second example is much more readable, and a human can easily see where the list of strings begins to differ.

This may not be the only place in the code where this kind of change would be helpful, but it solves my current need, so I'm only proposing this one.

Thanks.