### PR TITLE
Optionally don't print anything about skipped tests

### DIFF
--- a/bin/buttercup
+++ b/bin/buttercup
@@ -31,6 +31,11 @@ Buttercup options:
                           which case tests will be run if they match
                           any of the given patterns.
 
+--silent-skipping, -s   When a test is skipped due to patterns or
+                          `xit' form, don't print anything about it.
+                          Likewise, don't omit all suite output if all
+                          specs inside it are skipped.
+
 --no-color, -c          Do not colorize test output.
 
 --traceback STYLE       When printing backtraces for errors that occur
@@ -70,7 +75,7 @@ do
             shift
             shift
             ;;
-        "-c"|"--no-color")
+        "-c"|"--no-color"|"-s"|"--silent-skipping")
             BUTTERCUP_ARGS+=("$1")
             shift
             ;;

--- a/bin/buttercup
+++ b/bin/buttercup
@@ -32,7 +32,7 @@ Buttercup options:
                           any of the given patterns.
 
 --silent-skipping, -s   When a test is skipped due to patterns or
-                          `xit' form, don't print anything about it.
+                          "xit" form, don't print anything about it.
                           Likewise, don't omit all suite output if all
                           specs inside it are skipped.
 

--- a/buttercup.el
+++ b/buttercup.el
@@ -1539,6 +1539,11 @@ EVENT and ARG are described in `buttercup-reporter'."
 (defvar buttercup-reporter-batch--failures nil
   "List of failed specs of the current batch report.")
 
+(defvar buttercup--pending-output t
+  "List of pending output strings, reversed.
+Can also be symbol t to print any output immediately. The list
+can contain nil items that serve as level separators.")
+
 (defun buttercup-reporter-batch (event arg)
   "A reporter that handles batch sessions.
 
@@ -1729,11 +1734,6 @@ EVENT and ARG are described in `buttercup-reporter'."
      ;; Fall through to buttercup-reporter-batch implementation.
      (buttercup-reporter-batch event arg)))
   )
-
-(defvar buttercup--pending-output t
-  "List of pending output strings, reversed.
-Can also be symbol t to print any output immediately. The list
-can contain nil items that serve as level separators.")
 
 (defun buttercup--print (fmt &rest args)
   "Format a string and send it to terminal without alteration.

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1130,6 +1130,7 @@
       (buttercup--print "2")
       (buttercup--discard-one-output-level)
       (buttercup--print "3")
+      (expect 'send-string-to-terminal :to-have-been-called-times 0)
       (buttercup--flush-pending-output))
 
     (expect 'send-string-to-terminal :to-have-been-called-times 2)


### PR DESCRIPTION
Here is an implementation of the feature of "don't print anything about skipped tests" I proposed in issue #161. The diff might look somewhat big, but it is only addition of new code, there are no removals. This can be verified by rediffing it with whitespace ignored: all "remove" hunks are only because of reindenting.

Everything revolves around new variable `buttercup-silent-skipping`. I initialized it to nil to preserve current behavior, but personally think default value of t would be more logical.

When this variable is non-nil, all output from Buttercup is put on hold and kept in the list `buttercup--pending-output`. This is done because when we discover that a test is skipped, we need to "erase" already generated output, possibly going as far as not mentioning its suite at all (if everything in the suite is skipped). Other implementations are possible by not running anything skipped at all or changing order of events, introducing new events, etc., but this all would break backward compatibility. Proposed implementation only alters the built-in reporters, not touching the way tests are executed at all.

External reporters will not get skipping functionality for free, but they can implement something similar based on new function `buttercup-spec-omitted-p`.

I added two tests for new functions. Can write more if needed.

New functionality is available from command line too. Here is an example:

    $ ./bin/buttercup -L . -p functions -s
    Running 117 specs.
    
    The `buttercup--apply-matcher' function
      should work with functions (34.13ms)
    
    The Spy 
      `spy-on' function
        can spy on autoloaded functions (14.85ms)
    
    Ran 2 out of 117 specs, 0 failed, in 0.1 seconds.
    paul@gonzo:~/git/buttercup$ 
