### PR TITLE
Raise an error if spy-on is used in the wrong context

### DIFF
--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -367,9 +367,9 @@ frameworks call these mocks and similar, we call them spies, because
 their main job is to spy in on function calls. Also, Jasmine calls
 them spies, and so do we. A spy can stub any function - whether it
 already exists or not - and tracks calls
-to it and all arguments. A spy only exists in the `describe` or `it`
-block it is defined in, and will be activated before and deactivated
-and reset after each spec. There are
+to it and all arguments. Spies may only be created in `before-each` or
+`it` blocks. Spies are removed and all counters reset after each spec
+and its `after-each` blocks have completed. There are
 special matchers for interacting with spies. The
 `:to-have-been-called` matcher will return true if the spy was called
 at all. The `:to-have-been-called-with` matcher will return true if

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -329,7 +329,7 @@
          buttercup--after-each
          buttercup--before-all
          buttercup--before-each
-         buttercup--cleanup-functions
+         (buttercup--cleanup-functions :invalid)
          buttercup--current-suite
          (buttercup-reporter #'ignore)
          buttercup-suites
@@ -696,7 +696,20 @@
          :not :to-throw)
         (expect
          (test-function 1 2)
-         :to-throw 'error)))
+         :to-throw 'error))
+
+      (describe "will signal en error if"
+        (it "used in before-all"
+          (with-local-buttercup
+            (let ((suite (describe "A bad spy scope"
+                           (before-all
+                             (spy-on 'some-function)))))
+              (expect (run--suite suite)
+                      :to-throw))))
+        (it "used directly in describe"
+          (with-local-buttercup
+            (expect (describe "Not in describe"
+                      (spy-on 'foo)) :to-throw)))))
 
     (describe ":to-have-been-called matcher"
       (before-each


### PR DESCRIPTION
`spy-on` is only allowed inside a `buttercup-with-cleanup`
environment.  Ensure this by raising errors when used wrong.  Some of
these errors will be signaled while reading the tests, but some (like in
`before-each`) will be signaled when the tests are run.

The `buttercup--cleanup-functions` variable gets a new default value
that does not satisfy `listp`.  This non-list value is used to detect
when `spy-on` is called in an invalid context.

Fixes #122.


----

#