### PR TITLE
Do not report skipped specs

### DIFF
--- a/bin/buttercup
+++ b/bin/buttercup
@@ -31,6 +31,11 @@ Buttercup options:
                           which case tests will be run if they match
                           any of the given patterns.
 
+--silent-skipping, -s   When a test is skipped due to patterns or
+                          "xit" form, don't print anything about it.
+                          Likewise, don't omit all suite output if all
+                          specs inside it are skipped.
+
 --no-color, -c          Do not colorize test output.
 
 --traceback STYLE       When printing backtraces for errors that occur
@@ -70,7 +75,7 @@ do
             shift
             shift
             ;;
-        "-c"|"--no-color")
+        "-c"|"--no-color"|"-s"|"--silent-skipping")
             BUTTERCUP_ARGS+=("$1")
             shift
             ;;


### PR DESCRIPTION
When `buttercup-silent-skipping` is non-nil, do not print specs that
were marked as skipped before `buttercup-run` was started.  Also do
not print the descriptions for suites that only contain such skipped
specs.

Specs that are marked as skipped by `assume` will still be printed.

Add an option `--silent-skipping` to bin/buttercup.