### PR TITLE
Optionally don't print anything about skipped and/or passed tests

### DIFF
--- a/bin/buttercup
+++ b/bin/buttercup
@@ -31,6 +31,15 @@ Buttercup options:
                           which case tests will be run if they match
                           any of the given patterns.
 
+--silent-skipping, -s   When a test is skipped due to patterns or
+                          "xit" form, don't print anything about it.
+                          Likewise, don't omit all suite output if all
+                          specs inside it are skipped.
+
+--quiet, -q             Only print failed tests. Silently omit all
+                          output for passed and skipped ones.  Implies
+                          "--silent-skipping".
+
 --no-color, -c          Do not colorize test output.
 
 --traceback STYLE       When printing backtraces for errors that occur
@@ -70,7 +79,7 @@ do
             shift
             shift
             ;;
-        "-c"|"--no-color")
+        "-c"|"--no-color"|"-s"|"--silent-skipping"|"-q"|"--quiet")
             BUTTERCUP_ARGS+=("$1")
             shift
             ;;
@@ -87,4 +96,5 @@ do
     esac
 done
 
-exec "$EMACS_BIN" -batch "${EMACS_ARGS[@]}" -l buttercup -f buttercup-run-discover "${BUTTERCUP_ARGS[@]}"
+# `--' is needed so that Buttercup options don't get parsed by Emacs itself.
+exec "$EMACS_BIN" -batch "${EMACS_ARGS[@]}" -l buttercup -f buttercup-run-discover -- "${BUTTERCUP_ARGS[@]}"

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1102,6 +1102,30 @@
         (expect (buttercup-run) :not :to-throw)
         (expect 'runner :to-have-been-called-times 5)))))
 
+;; (describe "The `buttercup-reporter-delaying-adapter` function"
+;;   :var (suite-1 suite-1-1 spec-1-1-1 spec 1-1-2 suite-2 spec-2-1 reporter)
+;;   (before-each
+;;     (ignore reporter)
+;;     (setf suite-1    (make-buttercup-suite :description "suite 1")
+;;           suite-1-1  (make-buttercup-suite :description "suite 1-1")
+;;           spec-1-1-1 (make-buttercup-spec :description "spec 1-1-1")
+;;           spec-1-1-2 (make-buttercup-spec :description "spec 1-1-2")
+;;           suite-2    (make-buttercup-suite :description "suite 2")
+;;           spec-2-1   (make-buttercup-spec :description "spec 2-1"))
+;;     (buttercup-suite-add-child suite-1 suite-1-1)
+;;     (buttercup-suite-add-child suite-1-1 spec-1-1-1)
+;;     (buttercup-suite-add-child suite-1-1 spec-1-1-2)
+;;     (buttercup-suite-add-child suite-2 spec-2-1)
+;;     (spy-on 'reporter))
+
+;;   (it "should pass events through"
+;;     (with-local-buttercup
+;;       (cl-letf ((buttercup-reporter (buttercup-reporter-delaying-adapter 'reporter))
+;;                 (buttercup-silent-skipping nil))
+;;         (let ((buttercup-suites (list suite-1 suite-2)))
+;;           (buttercup-run)
+;;           (expect 'reporter :to-have-been-called-times 14))))))
+
 (describe "The `buttercup--print' function"
   (before-each
     (spy-on 'send-string-to-terminal))


### PR DESCRIPTION
Yet another implementation of the feature of "don't print anything about skipped tests" from issue #161. Additionally this implements one more option `-q`. When that is set, Buttercup prints *only* failed tests (with `-s` it prints failed and passed, by default it prints all, including skipped, as now).

This implementation adds function `buttercup-reporter-delaying-adapter` that can sit in front of any reporter and filter events sent to it according to variables `buttercup-silent-skipping` and `buttercup-quiet`. Unlike other proposed implementations, this can be used for *any* reporter by adding a single call to the adapter.

The implementation is also fairly small and almost doesn't touch existing code. It's quite unobvious, but I didn't add any comments since I felt like I would comment every single line then.

I failed to write tests (only tested manually) for this implementation, some commented-out attempt is in the commit. @snogge: can you help with this?