### PR TITLE
Allow clean abort

### DIFF
--- a/bin/buttercup
+++ b/bin/buttercup
@@ -31,6 +31,8 @@ Buttercup options:
                           which case tests will be run if they match
                           any of the given patterns.
 
+--abort-on-failure, -a  Abort test execution if any test fails.
+
 --no-color, -c          Do not colorize test output.
 
 --traceback STYLE       When printing backtraces for errors that occur
@@ -70,7 +72,7 @@ do
             shift
             shift
             ;;
-        "-c"|"--no-color")
+        "-c"|"--no-color"|"-a"|"--abort-on-failure")
             BUTTERCUP_ARGS+=("$1")
             shift
             ;;

--- a/buttercup.el
+++ b/buttercup.el
@@ -671,6 +671,9 @@ See also `buttercup-define-matcher'."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Suite and spec data structures
 
+(defvar buttercup-stop-on-first-failure nil
+  "Abort Buttercup testing if any spec fails.")
+
 (cl-defstruct buttercup-suite-or-spec
   ;; The name of this specific suite
   description
@@ -1355,6 +1358,9 @@ current directory."
        ((member (car args) '("-c" "--no-color"))
         (setq buttercup-color nil)
         (setq args (cdr args)))
+       ((member (car args) '("-a" "--abort-on-failure"))
+        (setq buttercup-stop-on-first-failure t)
+        (setq args (cdr args)))
        (t
         (push (car args) dirs)
         (setq args (cdr args)))))
@@ -1517,7 +1523,9 @@ failed and pending specs."
                 '(passed pending))
       (setf (buttercup-suite-or-spec-status suite-or-spec) status
             (buttercup-suite-or-spec-failure-description suite-or-spec) description
-            (buttercup-suite-or-spec-failure-stack suite-or-spec) stack))))
+            (buttercup-suite-or-spec-failure-stack suite-or-spec) stack)
+      (when (and buttercup-stop-on-first-failure (eq status 'failed))
+        (signal 'buttercup-abort "Aborting early because of the failure")))))
 
 ;;;;;;;;;;;;;
 ;;; Reporters

--- a/buttercup.el
+++ b/buttercup.el
@@ -117,6 +117,14 @@ a call to `save-match-data', as `format-spec' modifies that."
 (define-error 'buttercup-pending
   "Buttercup test is pending")
 
+(define-error 'buttercup-abort
+  "Abort Buttercup testing")
+
+(defvar buttercup-abort-message nil
+  "The message explaining why Buttercup testing is aborted.
+Reporters may want to print it if non-nil when handling
+`buttercup-done' event.")
+
 (defmacro expect (arg &optional matcher &rest args)
   "Expect a condition to be true.
 
@@ -1416,12 +1424,15 @@ A suite must be defined within a Markdown \"lisp\" code block."
 (defun buttercup-run ()
   "Run all described suites."
   (if buttercup-suites
-      (progn
+      (let (buttercup-abort-message)
         (funcall buttercup-reporter 'buttercup-started buttercup-suites)
-        (mapc #'buttercup--run-suite buttercup-suites)
-        (funcall buttercup-reporter 'buttercup-done buttercup-suites)
-        (when (> (buttercup-suites-total-specs-failed buttercup-suites) 0)
-          (error "")))
+        (unwind-protect
+            (condition-case error
+                (mapc #'buttercup--run-suite buttercup-suites)
+              (buttercup-abort (setf buttercup-abort-message (cdr error))))
+          (funcall buttercup-reporter 'buttercup-done buttercup-suites)
+          (when (> (buttercup-suites-total-specs-failed buttercup-suites) 0)
+            (error ""))))
     (error "No suites defined")))
 
 (defvar buttercup--before-each nil
@@ -1442,18 +1453,20 @@ Do not change the global value.")
          (buttercup--after-each (append (buttercup-suite-after-each suite)
                                         buttercup--after-each)))
     (funcall buttercup-reporter 'suite-started suite)
-    (dolist (f (buttercup-suite-before-all suite))
-      (buttercup--update-with-funcall suite f))
-    (dolist (sub (buttercup-suite-children suite))
-      (cond
-       ((buttercup-suite-p sub)
-        (buttercup--run-suite sub))
-       ((buttercup-spec-p sub)
-        (buttercup--run-spec sub))))
-    (dolist (f (buttercup-suite-after-all suite))
-      (buttercup--update-with-funcall suite f))
-    (buttercup--set-end-time suite)
-    (funcall buttercup-reporter 'suite-done suite)))
+    (unwind-protect
+        (progn
+          (dolist (f (buttercup-suite-before-all suite))
+            (buttercup--update-with-funcall suite f))
+          (dolist (sub (buttercup-suite-children suite))
+            (cond
+             ((buttercup-suite-p sub)
+              (buttercup--run-suite sub))
+             ((buttercup-spec-p sub)
+              (buttercup--run-spec sub))))
+          (dolist (f (buttercup-suite-after-all suite))
+            (buttercup--update-with-funcall suite f)))
+      (buttercup--set-end-time suite)
+      (funcall buttercup-reporter 'suite-done suite))))
 
 (defun buttercup--run-spec (spec)
   (buttercup--set-start-time spec)
@@ -1465,13 +1478,14 @@ Do not change the global value.")
         (get-buffer-create buttercup-warning-buffer-name)
 
         (funcall buttercup-reporter 'spec-started spec)
-        (buttercup-with-cleanup
-         (dolist (f buttercup--before-each)
-           (buttercup--update-with-funcall spec f))
-         (buttercup--update-with-funcall spec (buttercup-spec-function spec))
-         (dolist (f buttercup--after-each)
-           (buttercup--update-with-funcall spec f)))
-        (funcall buttercup-reporter 'spec-done spec)
+        (unwind-protect
+            (buttercup-with-cleanup
+             (dolist (f buttercup--before-each)
+               (buttercup--update-with-funcall spec f))
+             (buttercup--update-with-funcall spec (buttercup-spec-function spec))
+             (dolist (f buttercup--after-each)
+               (buttercup--update-with-funcall spec f)))
+          (funcall buttercup-reporter 'spec-done spec))
         ;; Display warnings that were issued while running the the
         ;; spec, if any
         (with-current-buffer buttercup-warning-buffer-name
@@ -1581,6 +1595,8 @@ EVENT and ARG are described in `buttercup-reporter'."
        (dolist (failed buttercup-reporter-batch--failures)
          (let ((description (buttercup-spec-failure-description failed))
                (stack (buttercup-spec-failure-stack failed)))
+           (when buttercup-abort-message
+             (buttercup--print "%s\n" (if (stringp buttercup-abort-message) buttercup-abort-message (prin1-to-string buttercup-abort-message))))
            (buttercup--print "%s\n" (make-string 40 ?=))
            (buttercup--print "%s\n" (buttercup-spec-full-name failed))
            (when stack
@@ -1657,6 +1673,8 @@ EVENT and ARG are described in `buttercup-reporter'."
      (dolist (failed buttercup-reporter-batch--failures)
        (let ((description (buttercup-spec-failure-description failed))
              (stack (buttercup-spec-failure-stack failed)))
+         (when (stringp buttercup-abort-message)
+           (buttercup--print "%s\n" (buttercup-colorize buttercup-abort-message 'red)))
          (buttercup--print "%s\n" (make-string 40 ?=))
          (buttercup--print (buttercup-colorize "%s\n" 'red) (buttercup-spec-full-name failed))
          (when stack

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -332,6 +332,7 @@
          buttercup--cleanup-functions
          buttercup--current-suite
          (buttercup-reporter #'ignore)
+         buttercup-stop-on-first-failure
          buttercup-suites
          (buttercup-warning-buffer-name " *ignored buttercup warnings*"))
      ,@body))


### PR DESCRIPTION
Would Buttercup be interested in the following functionality?

1. Test run can be aborted cleanly at any point (by a test, by the reporter). "Cleanly" means that corresponding `*-done` for started specs and suites are emitted, the run ends in `buttercup-done` event, but no more specs are executed after aborting.

2. New option: immediately abort if a test fails. This is useful if your tests are so interdependent (at least in the context of the current bug) that one failure typically means there will be 20 more. Also when tests are slow enough that you don't want to wait for all of them to finish to get the backtrace of the first failure.