### PR TITLE
Fix status overwrites #149 and #157

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -1510,8 +1510,13 @@ failed and pending specs."
         (`(error (buttercup-pending . ,pending-description))
          (setq status 'pending
                description pending-description))))
-    (when (memq (buttercup-suite-or-spec-status suite-or-spec)
-                '(passed pending))
+    ;; Only change state when the new state is 'worse' than or same as
+    ;; the current state. The constant list is the prioritized list of
+    ;; states. The new state is worse if it is in the tail of the
+    ;; current state.
+    (when (memq status
+                (memq (buttercup-suite-or-spec-status suite-or-spec)
+                      '(passed pending failed)))
       (setf (buttercup-suite-or-spec-status suite-or-spec) status
             (buttercup-suite-or-spec-failure-description suite-or-spec) description
             (buttercup-suite-or-spec-failure-stack suite-or-spec) stack))))

--- a/buttercup.el
+++ b/buttercup.el
@@ -845,7 +845,8 @@ is a function containing the body instructions passed to
            (format "Found duplicate spec names in suite: %S"
                    (delete-dups dups)))))
       (setq buttercup-suites (append buttercup-suites
-                                     (list buttercup--current-suite))))))
+                                     (list buttercup--current-suite)))
+      buttercup--current-suite)))
 
 ;;;;;;;;;;;;;
 ;;; Specs: it

--- a/buttercup.el
+++ b/buttercup.el
@@ -691,11 +691,13 @@ See also `buttercup-define-matcher'."
   function)
 
 (defun buttercup-suite-add-child (parent child)
-  "Add a CHILD suite to a PARENT suite."
+  "Add a CHILD suite to a PARENT suite.
+Return CHILD."
   (setf (buttercup-suite-children parent)
         (append (buttercup-suite-children parent)
                 (list child)))
-  (setf (buttercup-suite-or-spec-parent child) parent))
+  (setf (buttercup-suite-or-spec-parent child) parent)
+  child)
 
 (defun buttercup-suite-or-spec-parents (suite-or-spec)
   "Return a list of parents of SUITE-OR-SPEC."
@@ -868,7 +870,8 @@ most probably including one or more calls to `expect'."
   "Function to handle an `it' form.
 
 DESCRIPTION has the same meaning as in `it'. BODY-FUNCTION is a
-function containing the body instructions passed to `it'."
+function containing the body instructions passed to `it'. Return
+the created spec object."
   (declare (indent 1))
   (when (not buttercup--current-suite)
     (error "`it' has to be called from within a `describe' form"))
@@ -1006,17 +1009,18 @@ DESCRIPTION is a string. BODY is ignored."
   "Like `buttercup-it', but mark the spec as disabled.
 A disabled spec is not run.
 
-DESCRIPTION has the same meaning as in `xit'. FUNCTION is ignored."
+DESCRIPTION has the same meaning as in `xit'. FUNCTION is
+ignored. Return the created spec object."
   (declare (indent 1))
   (ignore function)
-  (buttercup-it description (lambda ()
-                              (signal 'buttercup-pending "PENDING")))
-  (let ((spec (car (last (buttercup-suite-children
-                          buttercup--current-suite)))))
+  (let ((spec (buttercup-it description
+                (lambda ()
+                  (signal 'buttercup-pending "PENDING")))))
     (setf (buttercup-spec-status spec)
           'pending
           (buttercup-spec-failure-description spec)
-          "")))
+          "")
+    spec))
 
 ;;;;;;;;;
 ;;; Spies

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -179,24 +179,26 @@
 ;;; Suite and spec data structures
 
 (describe "The `buttercup-suite-add-child' function"
-  (it "should add an element at the end of the list"
+  (it "should add an element at the end of the list and return it"
     (let* ((specs (list (make-buttercup-spec)
                         (make-buttercup-spec)
                         (make-buttercup-spec)))
            (suite (make-buttercup-suite :children specs))
            (spec (make-buttercup-spec)))
 
-      (buttercup-suite-add-child suite spec)
+      (expect (buttercup-suite-add-child suite spec)
+              :to-be spec)
 
       (expect (buttercup-suite-children suite)
               :to-equal
               (append specs (list spec)))))
 
-  (it "should add an element even if the list is empty"
+  (it "should add an element even if the list is empty and return it"
     (let ((suite (make-buttercup-suite :children nil))
           (spec (make-buttercup-spec)))
 
-      (buttercup-suite-add-child suite spec)
+      (expect (buttercup-suite-add-child suite spec)
+              :to-be spec)
 
       (expect (buttercup-suite-children suite)
               :to-equal
@@ -444,11 +446,12 @@
               (buttercup-it "" (lambda ())))
             :to-throw))
 
-  (it "should add a spec to the current suite"
+  (it "should add a spec to the current suite and return the spec"
     (let ((buttercup--current-suite (make-buttercup-suite)))
-      (buttercup-it "the test spec"
-        (lambda () 23))
-      (let ((spec (car (buttercup-suite-children buttercup--current-suite))))
+      (let* ((created (buttercup-it "the test spec"
+                        (lambda () 23)))
+             (spec (car (buttercup-suite-children buttercup--current-suite))))
+        (expect created :to-be spec)
         (expect (buttercup-spec-description spec)
                 :to-equal
                 "the test spec")


### PR DESCRIPTION
I guess I've come full circle now, and am back at carefully selecting when the state should be updated in `buttercup--update-with-funcall`.  This is not to say that some of the ideas that have come up during the discussion of #149 wont be implemented eventually, but it is time to put this issue to rest. 

I will merge this in a day or two, just giving interested parties some time to weigh in.