### PR TITLE
Handle colored Multiline descriptions without garbled output

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -1651,6 +1651,9 @@ colors.
 
 EVENT and ARG are described in `buttercup-reporter'."
   (pcase event
+    (`spec-started
+     (unless (string-match-p "[\n\v\f]" (buttercup-spec-description arg))
+       (buttercup-reporter-batch event arg)))
     (`spec-done
      (let ((level (length (buttercup-suite-or-spec-parents arg))))
        (cond

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1123,12 +1123,20 @@ text properties using `ansi-color-apply'."
     (describe "on the suite-started event"
       (it "should emit an indented suite description"
         (buttercup-reporter-batch 'suite-started child-suite)
-        (expect (buttercup-output) :to-equal "  child-suite\n")))
+        (expect (buttercup-output) :to-equal-including-properties "  child-suite\n"))
+
+      (it "should color-print an indented suite description with the default color"
+        (buttercup-reporter-batch-color 'suite-started child-suite)
+        (expect (buttercup-output) :to-equal-including-properties "  child-suite\n")))
 
     (describe "on the spec-started event"
       (it "should emit an indented spec description"
         (buttercup-reporter-batch 'spec-started spec)
-        (expect (buttercup-output) :to-equal "    spec")))
+        (expect (buttercup-output) :to-equal-including-properties "    spec"))
+
+      (it "should color-print an indented spec description with the default color"
+        (buttercup-reporter-batch-color 'spec-started spec)
+        (expect (buttercup-output) :to-equal-including-properties "    spec")))
 
     (describe "on the spec-done event"
       (it "should print no status tag for a passed spec"

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1088,11 +1088,24 @@ text properties using `ansi-color-apply'."
       (setq print-buffer nil))
 
     (describe "on the buttercup-started event"
+      :var (skipped
+            ;; Local var for testing. The real variable is used by the
+            ;; reporter attached to the buttercup instance running
+            ;; these tests.
+            buttercup-reporter-batch--start-time)
+      (before-each
+        (setq skipped (make-buttercup-spec :description "skipped" :status 'pending)))
+
       (it "should print the number of specs"
-        (let ((buttercup-reporter-batch--start-time nil)
-              (buttercup-reporter-batch--failures nil))
+        (let ((buttercup-reporter-batch--failures nil))
           (buttercup-reporter-batch 'buttercup-started (list parent-suite)))
-        (expect (buttercup-output) :to-equal "Running 1 specs.\n\n")))
+        (expect (buttercup-output) :to-equal "Running 1 specs.\n\n"))
+
+      (it "should print the number of skipped specs"
+        (let ((buttercup-reporter-batch--failures nil))
+          (buttercup-suite-add-child child-suite skipped)
+          (buttercup-reporter-batch 'buttercup-started (list parent-suite)))
+        (expect (buttercup-output) :to-equal "Running 1 out of 2 specs.\n\n")))
 
     (describe "on the suite-started event"
       (it "should emit an indented suite description"

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1109,27 +1109,30 @@ text properties using `ansi-color-apply'."
         (buttercup--set-start-time spec)
         (setf (buttercup-spec-failure-description spec) "DONTSHOW")
         (buttercup--set-end-time spec)
+        (buttercup-reporter-batch 'spec-started spec)
         (buttercup-reporter-batch 'spec-done spec)
         (expect (buttercup-output) :to-equal
-                (format " (%s)\n" (buttercup-elapsed-time-string spec)))
-        )
+                (format "    spec (%s)\n"
+                        (buttercup-elapsed-time-string spec))))
 
       (it "should say FAILED for a failed spec"
         (setf (buttercup-spec-status spec) 'failed)
         (let ((buttercup-reporter-batch--failures nil))
+          (buttercup-reporter-batch 'spec-started spec)
           (buttercup-reporter-batch 'spec-done spec))
         (expect (buttercup-output) :to-equal
-                (format "  FAILED (%s)\n" (buttercup-elapsed-time-string spec)))
-        )
+                (format "    spec  FAILED (%s)\n"
+                        (buttercup-elapsed-time-string spec))))
 
       (it "should output the failure-description for a pending spec"
         (setf (buttercup-spec-status spec) 'pending
               (buttercup-spec-failure-description spec) "DESCRIPTION")
         (let ((buttercup-reporter-batch--failures nil))
+          (buttercup-reporter-batch 'spec-started spec)
           (buttercup-reporter-batch 'spec-done spec))
         (expect (buttercup-output) :to-equal
-                (format "  DESCRIPTION (%s)\n" (buttercup-elapsed-time-string spec)))
-        )
+                (format "    spec  DESCRIPTION (%s)\n"
+                        (buttercup-elapsed-time-string spec))))
 
       (it "should throw an error for an unknown spec status"
         (setf (buttercup-spec-status spec) 'unknown)

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1158,6 +1158,23 @@ text properties using `ansi-color-apply'."
           (expect (buttercup-output) :to-equal-including-properties
                   (ansi-color-apply
                    (format "\e[32m    spec\e[0m (%s)\n"
+                           (buttercup-elapsed-time-string spec)))))
+
+        (it "should print multiline specs cleanly"
+          (setf (buttercup-spec-description spec) "one\ntwo\vthree")
+          (buttercup-reporter-batch 'spec-started spec)
+          (buttercup-reporter-batch 'spec-done spec)
+          (expect (buttercup-output) :to-equal-including-properties
+                  (format "    one\ntwo\n   three (%s)\n"
+                          (buttercup-elapsed-time-string spec))))
+
+        (it "should color-print multiline specs cleanly"
+          (setf (buttercup-spec-description spec) "one\ntwo\vthree")
+          (buttercup-reporter-batch-color 'spec-started spec)
+          (buttercup-reporter-batch-color 'spec-done spec)
+          (expect (buttercup-output) :to-equal-including-properties
+                  (ansi-color-apply
+                   (format "\e[32m    one\ntwo\n   three\e[0m (%s)\n"
                            (buttercup-elapsed-time-string spec))))))
 
       (describe "for a failed spec"

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1215,11 +1215,19 @@ text properties using `ansi-color-apply'."
     (describe "on the suite-done event"
       (it "should emit a newline at the end of the top-level suite"
         (buttercup-reporter-batch 'suite-done parent-suite)
-        (expect (buttercup-output) :to-equal "\n"))
+        (expect (buttercup-output) :to-equal-including-properties "\n"))
+
+      (it "should color-print a newline at the end of the top-level suite"
+        (buttercup-reporter-batch-color 'suite-done parent-suite)
+        (expect (buttercup-output) :to-equal-including-properties "\n"))
 
       (it "should not emit anything at the end of other suites"
         (buttercup-reporter-batch 'suite-done child-suite)
-        (expect (buttercup-output) :to-equal "")))
+        (expect (buttercup-output) :to-equal-including-properties ""))
+
+      (it "should not color-print anything at the end of other suites"
+        (buttercup-reporter-batch-color 'suite-done child-suite)
+        (expect (buttercup-output) :to-equal-including-properties "")))
 
     (describe "on the buttercup-done event"
       :var ((buttercup-reporter-batch--start-time (current-time))

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1064,8 +1064,10 @@ text properties using `ansi-color-apply'."
 
 ;;;;;;;;;;;;;
 ;;; Reporters
+(buttercup-define-matcher-for-binary-function
+    :to-equal-including-properties equal-including-properties)
 
-(describe "The batch reporter"
+(describe "The batch reporters"
   :var (print-buffer)
   (let (parent-suite child-suite spec)
     (before-each
@@ -1099,13 +1101,24 @@ text properties using `ansi-color-apply'."
       (it "should print the number of specs"
         (let ((buttercup-reporter-batch--failures nil))
           (buttercup-reporter-batch 'buttercup-started (list parent-suite)))
-        (expect (buttercup-output) :to-equal "Running 1 specs.\n\n"))
+        (expect (buttercup-output) :to-equal-including-properties "Running 1 specs.\n\n"))
+
+      (it "should color-print the number of specs with the default color"
+        (let (buttercup-reporter-batch--failures)
+          (buttercup-reporter-batch-color 'buttercup-started (list parent-suite)))
+        (expect (buttercup-output) :to-equal-including-properties "Running 1 specs.\n\n"))
 
       (it "should print the number of skipped specs"
         (let ((buttercup-reporter-batch--failures nil))
           (buttercup-suite-add-child child-suite skipped)
           (buttercup-reporter-batch 'buttercup-started (list parent-suite)))
-        (expect (buttercup-output) :to-equal "Running 1 out of 2 specs.\n\n")))
+        (expect (buttercup-output) :to-equal-including-properties "Running 1 out of 2 specs.\n\n"))
+
+      (it "should color-print the number of skipped specs with the default color"
+        (let (buttercup-reporter-batch--failures)
+          (buttercup-suite-add-child child-suite skipped)
+          (buttercup-reporter-batch-color 'buttercup-started (list parent-suite)))
+        (expect (buttercup-output) :to-equal-including-properties "Running 1 out of 2 specs.\n\n")))
 
     (describe "on the suite-started event"
       (it "should emit an indented suite description"

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1246,12 +1246,42 @@ text properties using `ansi-color-apply'."
         (expect (buttercup-output) :to-match
                 "Ran 10 specs, 6 failed, in [0-9]+.[0-9]+[mu]?s.\n"))
 
+      (it "should color-print `0 failed' specs in green"
+        (let (buttercup-reporter-batch--failures)
+          (buttercup-reporter-batch-color 'buttercup-done nil))
+        (expect (buttercup-output) :to-match
+                "Ran 10 specs, 0 failed, in [0-9]+.[0-9]+[mu]?s.\n")
+        (expect (substring (buttercup-output) 0 (length "Ran 10 specs, 0 failed, in"))
+                :to-equal-including-properties
+                (ansi-color-apply "Ran 10 specs,\e[32m 0 failed\e[0m, in")))
+
+      (it "should color-print `X failed' specs in red"
+        (setq failed-specs 6)
+        (let (buttercup-reporter-batch--failures)
+          (buttercup-reporter-batch-color 'buttercup-done nil))
+        (expect (buttercup-output) :to-match
+                "Ran 10 specs, 6 failed, in [0-9]+.[0-9]+[mu]?s.\n")
+        (expect (substring (buttercup-output) 0 (length "Ran 10 specs, 6 failed, in"))
+                :to-equal-including-properties
+                (ansi-color-apply "Ran 10 specs,\e[31m 6 failed\e[0m, in")))
+
       (it "should print a summary separating run and pending specs"
         (setq pending-specs 3)
         (let (buttercup-reporter-batch--failures)
           (buttercup-reporter-batch 'buttercup-done nil))
         (expect (buttercup-output) :to-match
                 "Ran 7 out of 10 specs, 0 failed, in [0-9]+.[0-9]+[mu]?s.\n"))
+
+      (it "should color-print pending spec count in default color"
+        (setq pending-specs 3)
+        (let (buttercup-reporter-batch--failures)
+          (buttercup-reporter-batch 'buttercup-done nil))
+        (expect (buttercup-output) :to-match
+                "Ran 7 out of 10 specs, 0 failed, in [0-9]+.[0-9]+[mu]?s.\n")
+        (expect (substring (buttercup-output)
+                           0 (length "Ran 7 out of 10 specs, 0 failed, in"))
+                :to-equal-including-properties
+                "Ran 7 out of 10 specs, 0 failed, in"))
 
       (it "should not raise any error even if a spec failed"
         (setf (buttercup-spec-status spec) 'failed)


### PR DESCRIPTION
A lot of work on the reporter tests, including new tests for the color reporter.
