### PR TITLE
Make sure carriage movement characters are not colorized

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -1653,25 +1653,25 @@ EVENT and ARG are described in `buttercup-reporter'."
      (unless (string-match-p "[\n\v\f]" (buttercup-spec-description arg))
        (buttercup-reporter-batch event arg)))
     (`spec-done
-       (cond
-        ((eq (buttercup-spec-status arg) 'passed)
-         (buttercup--print (buttercup-colorize "\r%s" 'green)
-                           (buttercup--indented-description arg)))
-        ((eq (buttercup-spec-status arg) 'failed)
-         (buttercup--print (buttercup-colorize "\r%s  FAILED" 'red)
-                           (buttercup--indented-description arg))
-         (setq buttercup-reporter-batch--failures
-               (append buttercup-reporter-batch--failures
-                       (list arg))))
-        ((eq (buttercup-spec-status arg) 'pending)
-         (if (equal (buttercup-spec-failure-description arg) "SKIPPED")
-             (buttercup--print "  %s" (buttercup-spec-failure-description arg))
-           (buttercup--print (buttercup-colorize "\r%s  %s" 'yellow)
-                             (buttercup--indented-description arg)
-                             (buttercup-spec-failure-description arg))))
-        (t
-         (error "Unknown spec status %s" (buttercup-spec-status arg))))
-       (buttercup--print " (%s)\n" (buttercup-elapsed-time-string arg)))
+     (pcase (buttercup-spec-status arg)
+       (`passed
+        (buttercup--print (buttercup-colorize "\r%s" 'green)
+                          (buttercup--indented-description arg)))
+       (`failed
+        (buttercup--print (buttercup-colorize "\r%s  FAILED" 'red)
+                          (buttercup--indented-description arg))
+        (setq buttercup-reporter-batch--failures
+              (append buttercup-reporter-batch--failures
+                      (list arg))))
+       (`pending
+        (if (equal (buttercup-spec-failure-description arg) "SKIPPED")
+            (buttercup--print "  %s" (buttercup-spec-failure-description arg))
+          (buttercup--print (buttercup-colorize "\r%s  %s" 'yellow)
+                            (buttercup--indented-description arg)
+                            (buttercup-spec-failure-description arg))))
+       (_
+        (error "Unknown spec status %s" (buttercup-spec-status arg))))
+     (buttercup--print " (%s)\n" (buttercup-elapsed-time-string arg)))
 
     (`buttercup-done
      (dolist (failed buttercup-reporter-batch--failures)


### PR DESCRIPTION
Fixes #171, which reports that adding `ansi-color-apply-on-region` to
`compilation-filter-hook` did not work with colorized buttercup output.
This was because in the `compilation-filter` function, carriage
movment characters `\r` and `\n` are handled (by
`comint-carriage-motion? ) before `compilation-filter-hook? .

It is often recommended to use
```emacs-lisp
;; either `point' or `point-max' work as the second argument
(ansi-color-apply-on-region compilation-filter-start (point))
```
in a `compilation-filter-hook` function to handle ANSI or SGR control
sequences in compilation output.  But carriage motion may cause
`point` to move to before `compilation-filter-start`.  Then
`ansi-color-apply-on-region` will miss SGR control sequences in the
`point` --- `compilation-filter-start` range.  Using
```emacs-lisp
(ansi-color-apply-on-region
    (save-excursion
        (goto-char compilation-filter-start)
        (line-beginning-position))
    (point))))
```
instead will at least avoid this problem for carriage motion that does
not move point to preceding lines.