### PR TITLE
Add API for better skip selection

### DIFF
--- a/bin/buttercup
+++ b/bin/buttercup
@@ -29,7 +29,10 @@ Buttercup options:
 --pattern, -p PATTERN   Only run tests with names matching PATTERN.
                           This option can be used multiple times, in
                           which case tests will be run if they match
-                          any of the given patterns.
+                          any of the given patterns. PATTERN is
+                          matched as a substring of the full test
+                          description (the concatenation of the test
+                          and all paremt suites descriptions).
 
 --no-color, -c          Do not colorize test output.
 

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -36,8 +36,15 @@
           items))
 
 (defmacro with-local-buttercup (&rest body)
-  "Execute BODY with local buttercup state variables."
+  "Execute BODY with local buttercup state variables.
+Keyword arguments kan be used to override the values of `buttercup-KEY'.
+\n(fn &keys COLOR SUITES REPORTER &rest BODY)"
   (declare (debug t) (indent defun))
+  ;; extract keyword arguments
+  (let ((keys '(:color buttercup-color :suites buttercup-suites :reporter buttercup-reporter))
+        extra-vars)
+    (while (plist-member keys (car body))
+      (push (list (plist-get keys (pop body)) (pop body)) extra-vars))
   `(let (buttercup--after-all
          buttercup--after-each
          buttercup--before-all
@@ -46,8 +53,9 @@
          buttercup--current-suite
          (buttercup-reporter #'ignore)
          buttercup-suites
-         (buttercup-warning-buffer-name " *ignored buttercup warnings*"))
-     ,@body))
+         (buttercup-warning-buffer-name " *ignored buttercup warnings*")
+         ,@(nreverse extra-vars))
+     ,@body)))
 
 (defun send-string-to-ansi-buffer (buffer string)
   "A `send-string-to-terminal' variant that sends STRING to BUFFER.


### PR DESCRIPTION
The new function `buttercup-mark-skipped` lets users mark specs as pending/skipped using either regular expressions or predicate functions.

@doublep , what do you think of this API?  Maybe we should supply more data to the predicate function, like the full description string?