### PR TITLE
Fold buttercup-reporter-batch-color into buttercup-reporter-batch

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -1586,9 +1586,7 @@ Calls either `buttercup-reporter-batch' or
 
 EVENT and ARG are described in `buttercup-reporter'."
   (if noninteractive
-      (if buttercup-color
-          (buttercup-reporter-batch-color event arg)
-        (buttercup-reporter-batch event arg))
+      (buttercup-reporter-batch event arg)
     (buttercup-reporter-interactive event arg)))
 
 (defvar buttercup-reporter-batch--start-time nil
@@ -1735,19 +1733,6 @@ Colorize parts of the output if COLOR is non-nil."
     (buttercup--print
      "Ran %d%s specs, %s, in %s.\n"
      (- defined pending) out-of failed-str duration)))
-
-(defun buttercup-reporter-batch-color (event arg)
-  "A reporter that handles batch sessions.
-
-Compared to `buttercup-reporter-batch', this reporter uses
-colors.
-
-EVENT and ARG are described in `buttercup-reporter'."
-  (pcase event
-    (_
-     ;; Fall through to buttercup-reporter-batch implementation.
-     (buttercup-reporter-batch event arg)))
-  )
 
 (defun buttercup--print (fmt &rest args)
   "Format a string and send it to terminal without alteration.

--- a/buttercup.el
+++ b/buttercup.el
@@ -1744,12 +1744,6 @@ colors.
 
 EVENT and ARG are described in `buttercup-reporter'."
   (pcase event
-    (`spec-done
-     (when (eq (buttercup-spec-status arg) 'failed)
-        (setq buttercup-reporter-batch--failures
-              (append buttercup-reporter-batch--failures
-                      (list arg))))
-     (buttercup-reporter-batch--print-spec-done-line arg buttercup-color))
     (_
      ;; Fall through to buttercup-reporter-batch implementation.
      (buttercup-reporter-batch event arg)))

--- a/buttercup.el
+++ b/buttercup.el
@@ -1792,9 +1792,12 @@ the capturing behavior."
      ,@body))
 
 (defun buttercup-colorize (string color)
-  "Format STRING with COLOR."
-  (let ((color-code (cdr (assoc color buttercup-colors))))
-    (format "\e[%sm%s\e[0m" color-code string)))
+  "Format STRING with COLOR.
+Return STRING unmodified if COLOR is nil."
+  (if color
+      (let ((color-code (cdr (assoc color buttercup-colors))))
+        (format "\e[%sm%s\e[0m" color-code string))
+    string))
 
 (defun buttercup-reporter-interactive (event arg)
   "Reporter for interactive sessions.

--- a/buttercup.el
+++ b/buttercup.el
@@ -1620,17 +1620,17 @@ EVENT and ARG are described in `buttercup-reporter'."
       (`spec-started
          (buttercup--print "%s" (buttercup--indented-description arg)))
       (`spec-done
-       (cond
-        ((eq (buttercup-spec-status arg) 'passed)) ; do nothing
-        ((eq (buttercup-spec-status arg) 'failed)
-         (buttercup--print "  FAILED")
-         (setq buttercup-reporter-batch--failures
-               (append buttercup-reporter-batch--failures
-                       (list arg))))
-        ((eq (buttercup-spec-status arg) 'pending)
-         (buttercup--print "  %s" (buttercup-spec-failure-description arg)))
-        (t
-         (error "Unknown spec status %s" (buttercup-spec-status arg))))
+       (pcase (buttercup-spec-status arg)
+         (`passed) ; do nothing
+         (`failed
+          (buttercup--print "  FAILED")
+          (setq buttercup-reporter-batch--failures
+                (append buttercup-reporter-batch--failures
+                        (list arg))))
+         (`pending
+          (buttercup--print "  %s" (buttercup-spec-failure-description arg)))
+         (_
+          (error "Unknown spec status %s" (buttercup-spec-status arg))))
        (buttercup--print " (%s)\n" (buttercup-elapsed-time-string arg)))
 
       (`suite-done

--- a/buttercup.el
+++ b/buttercup.el
@@ -1618,7 +1618,9 @@ EVENT and ARG are described in `buttercup-reporter'."
       (`suite-started
          (buttercup--print "%s\n" (buttercup--indented-description arg)))
       (`spec-started
-         (buttercup--print "%s" (buttercup--indented-description arg)))
+       (unless (and buttercup-color
+                    (string-match-p "[\n\v\f]" (buttercup-spec-description arg)))
+         (buttercup--print "%s" (buttercup--indented-description arg))))
       (`spec-done
        (pcase (buttercup-spec-status arg)
          (`passed) ; do nothing
@@ -1703,9 +1705,6 @@ colors.
 
 EVENT and ARG are described in `buttercup-reporter'."
   (pcase event
-    (`spec-started
-     (unless (string-match-p "[\n\v\f]" (buttercup-spec-description arg))
-       (buttercup-reporter-batch event arg)))
     (`spec-done
      ;; Carriage returns (\r) should not be colorized. It would mess
      ;; up color handling in Emacs compilation buffers using

--- a/buttercup.el
+++ b/buttercup.el
@@ -1639,8 +1639,8 @@ EVENT and ARG are described in `buttercup-reporter'."
 
       (`buttercup-done
        (dolist (failed buttercup-reporter-batch--failures)
-         (buttercup-reporter-batch--print-failed-spec-report failed nil))
-       (buttercup-reporter-batch--print-summary arg nil))
+         (buttercup-reporter-batch--print-failed-spec-report failed buttercup-color))
+       (buttercup-reporter-batch--print-summary arg buttercup-color))
 
       (_
        (error "Unknown event %s" event)))))
@@ -1733,11 +1733,6 @@ EVENT and ARG are described in `buttercup-reporter'."
        (_
         (error "Unknown spec status %s" (buttercup-spec-status arg))))
      (buttercup--print " (%s)\n" (buttercup-elapsed-time-string arg)))
-
-    (`buttercup-done
-     (dolist (failed buttercup-reporter-batch--failures)
-       (buttercup-reporter-batch--print-failed-spec-report failed t))
-     (buttercup-reporter-batch--print-summary arg buttercup-color))
 
     (_
      ;; Fall through to buttercup-reporter-batch implementation.

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1242,10 +1242,16 @@ text properties using `ansi-color-apply'."
                    (format "\e[33m    spec  DESCRIPTION\e[0m (%s)\n"
                         (buttercup-elapsed-time-string spec))))))
 
-      (it "should throw an error for an unknown spec status"
-        (setf (buttercup-spec-status spec) 'unknown)
-        (expect (buttercup-reporter-batch 'spec-done spec)
-                :to-throw)))
+      (describe "should throw an error for an unknown spec status"
+        (before-each (setf (buttercup-spec-status spec) 'unknown))
+        (it "for plain output"
+          (with-local-buttercup :color nil
+            (expect (buttercup-reporter-batch 'spec-done spec)
+                    :to-throw)))
+        (it "for colored output"
+          (with-local-buttercup :color t
+            (expect (buttercup-reporter-batch 'spec-done spec)
+                    :to-throw)))))
 
     (describe "on the suite-done event"
       (it "should emit a newline at the end of a top-level suite"

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1248,12 +1248,12 @@ text properties using `ansi-color-apply'."
                 :to-throw)))
 
     (describe "on the suite-done event"
-      (it "should emit a newline at the end of the top-level suite"
+      (it "should emit a newline at the end of a top-level suite"
         (with-local-buttercup :color nil
           (buttercup-reporter-batch 'suite-done parent-suite))
         (expect (buttercup-output) :to-equal-including-properties "\n"))
 
-      (it "should color-print a newline at the end of the top-level suite"
+      (it "should color-print a newline at the end of a top-level suite"
         (with-local-buttercup :color t
          (buttercup-reporter-batch-color 'suite-done parent-suite))
         (expect (buttercup-output) :to-equal-including-properties "\n"))

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1305,9 +1305,9 @@ text properties using `ansi-color-apply'."
         (expect (buttercup-output) :to-match
                 "Ran 7 out of 10 specs, 0 failed, in [0-9]+.[0-9]+[mu]?s.\n")
         (expect (substring (buttercup-output)
-                           0 (length "Ran 7 out of 10 specs, 0 failed, in"))
+                           0 (length "Ran 7 out of 10 specs"))
                 :to-equal-including-properties
-                "Ran 7 out of 10 specs, 0 failed, in"))
+                "Ran 7 out of 10 specs"))
 
       (it "should not raise any error even if a spec failed"
         (setf (buttercup-spec-status spec) 'failed)

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -53,6 +53,7 @@ Keyword arguments kan be used to override the values of `buttercup-KEY'.
          buttercup--current-suite
          (buttercup-reporter #'ignore)
          buttercup-suites
+         buttercup-reporter-batch--failures
          (buttercup-warning-buffer-name " *ignored buttercup warnings*")
          ,@(nreverse extra-vars))
      ,@body)))
@@ -1108,43 +1109,47 @@ text properties using `ansi-color-apply'."
         (setq skipped (make-buttercup-spec :description "skipped" :status 'pending)))
 
       (it "should print the number of specs"
-        (let ((buttercup-reporter-batch--failures nil))
+        (with-local-buttercup :color nil
           (buttercup-reporter-batch 'buttercup-started (list parent-suite)))
         (expect (buttercup-output) :to-equal-including-properties "Running 1 specs.\n\n"))
 
       (it "should color-print the number of specs with the default color"
-        (let (buttercup-reporter-batch--failures)
+        (with-local-buttercup :color t
           (buttercup-reporter-batch-color 'buttercup-started (list parent-suite)))
         (expect (buttercup-output) :to-equal-including-properties "Running 1 specs.\n\n"))
 
       (it "should print the number of skipped specs"
-        (let ((buttercup-reporter-batch--failures nil))
+        (with-local-buttercup :color nil
           (buttercup-suite-add-child child-suite skipped)
           (buttercup-reporter-batch 'buttercup-started (list parent-suite)))
         (expect (buttercup-output) :to-equal-including-properties "Running 1 out of 2 specs.\n\n"))
 
       (it "should color-print the number of skipped specs with the default color"
-        (let (buttercup-reporter-batch--failures)
+        (with-local-buttercup :color t
           (buttercup-suite-add-child child-suite skipped)
           (buttercup-reporter-batch-color 'buttercup-started (list parent-suite)))
         (expect (buttercup-output) :to-equal-including-properties "Running 1 out of 2 specs.\n\n")))
 
     (describe "on the suite-started event"
       (it "should emit an indented suite description"
-        (buttercup-reporter-batch 'suite-started child-suite)
+        (with-local-buttercup :color nil
+         (buttercup-reporter-batch 'suite-started child-suite))
         (expect (buttercup-output) :to-equal-including-properties "  child-suite\n"))
 
       (it "should color-print an indented suite description with the default color"
-        (buttercup-reporter-batch-color 'suite-started child-suite)
+        (with-local-buttercup :color t
+         (buttercup-reporter-batch-color 'suite-started child-suite))
         (expect (buttercup-output) :to-equal-including-properties "  child-suite\n")))
 
     (describe "on the spec-started event"
       (it "should emit an indented spec description"
-        (buttercup-reporter-batch 'spec-started spec)
+        (with-local-buttercup :color nil
+         (buttercup-reporter-batch 'spec-started spec))
         (expect (buttercup-output) :to-equal-including-properties "    spec"))
 
       (it "should color-print an indented spec description with the default color"
-        (buttercup-reporter-batch-color 'spec-started spec)
+        (with-local-buttercup :color t
+         (buttercup-reporter-batch-color 'spec-started spec))
         (expect (buttercup-output) :to-equal-including-properties "    spec")))
 
     (describe "on the spec-done event"
@@ -1155,15 +1160,17 @@ text properties using `ansi-color-apply'."
           (buttercup--set-end-time spec))
 
         (it "should print no status tag"
-          (buttercup-reporter-batch 'spec-started spec)
-          (buttercup-reporter-batch 'spec-done spec)
+          (with-local-buttercup :color nil
+           (buttercup-reporter-batch 'spec-started spec)
+           (buttercup-reporter-batch 'spec-done spec))
           (expect (buttercup-output) :to-equal-including-properties
                   (format "    spec (%s)\n"
                           (buttercup-elapsed-time-string spec))))
 
         (it "should color-print the description in green and no status tag"
-          (buttercup-reporter-batch-color 'spec-started spec)
-          (buttercup-reporter-batch-color 'spec-done spec)
+          (with-local-buttercup :color t
+           (buttercup-reporter-batch-color 'spec-started spec)
+           (buttercup-reporter-batch-color 'spec-done spec))
           (expect (buttercup-output) :to-equal-including-properties
                   (ansi-color-apply
                    (format "\e[32m    spec\e[0m (%s)\n"
@@ -1171,16 +1178,18 @@ text properties using `ansi-color-apply'."
 
         (it "should print multiline specs cleanly"
           (setf (buttercup-spec-description spec) "one\ntwo\vthree")
-          (buttercup-reporter-batch 'spec-started spec)
-          (buttercup-reporter-batch 'spec-done spec)
+          (with-local-buttercup :color nil
+           (buttercup-reporter-batch 'spec-started spec)
+           (buttercup-reporter-batch 'spec-done spec))
           (expect (buttercup-output) :to-equal-including-properties
                   (format "    one\ntwo\n   three (%s)\n"
                           (buttercup-elapsed-time-string spec))))
 
         (it "should color-print multiline specs cleanly"
           (setf (buttercup-spec-description spec) "one\ntwo\vthree")
-          (buttercup-reporter-batch-color 'spec-started spec)
-          (buttercup-reporter-batch-color 'spec-done spec)
+          (with-local-buttercup :color t
+           (buttercup-reporter-batch-color 'spec-started spec)
+           (buttercup-reporter-batch-color 'spec-done spec))
           (expect (buttercup-output) :to-equal-including-properties
                   (ansi-color-apply
                    (format "\e[32m    one\ntwo\n   three\e[0m (%s)\n"
@@ -1193,7 +1202,7 @@ text properties using `ansi-color-apply'."
           (buttercup--set-end-time spec))
 
         (it "should say FAILED"
-          (let ((buttercup-reporter-batch--failures nil))
+          (with-local-buttercup :color nil
             (buttercup-reporter-batch 'spec-started spec)
             (buttercup-reporter-batch 'spec-done spec))
           (expect (buttercup-output) :to-equal-including-properties
@@ -1201,7 +1210,7 @@ text properties using `ansi-color-apply'."
                           (buttercup-elapsed-time-string spec))))
 
         (it "should color-print the description in red and say FAILED"
-          (let ((buttercup-reporter-batch--failures nil))
+          (with-local-buttercup :color t
             (buttercup-reporter-batch-color 'spec-started spec)
             (buttercup-reporter-batch-color 'spec-done spec))
           (expect (buttercup-output) :to-equal-including-properties
@@ -1217,7 +1226,7 @@ text properties using `ansi-color-apply'."
           (buttercup--set-end-time spec))
 
         (it "should output the failure-description"
-          (let ((buttercup-reporter-batch--failures nil))
+          (with-local-buttercup :color nil
             (buttercup-reporter-batch 'spec-started spec)
             (buttercup-reporter-batch 'spec-done spec))
           (expect (buttercup-output) :to-equal-including-properties
@@ -1225,7 +1234,7 @@ text properties using `ansi-color-apply'."
                           (buttercup-elapsed-time-string spec))))
 
         (it "should color-print the description and failure-description in yellow"
-          (let ((buttercup-reporter-batch--failures nil))
+          (with-local-buttercup :color t
             (buttercup-reporter-batch-color 'spec-started spec)
             (buttercup-reporter-batch-color 'spec-done spec))
           (expect (buttercup-output) :to-equal-including-properties
@@ -1240,19 +1249,23 @@ text properties using `ansi-color-apply'."
 
     (describe "on the suite-done event"
       (it "should emit a newline at the end of the top-level suite"
-        (buttercup-reporter-batch 'suite-done parent-suite)
+        (with-local-buttercup :color nil
+          (buttercup-reporter-batch 'suite-done parent-suite))
         (expect (buttercup-output) :to-equal-including-properties "\n"))
 
       (it "should color-print a newline at the end of the top-level suite"
-        (buttercup-reporter-batch-color 'suite-done parent-suite)
+        (with-local-buttercup :color t
+         (buttercup-reporter-batch-color 'suite-done parent-suite))
         (expect (buttercup-output) :to-equal-including-properties "\n"))
 
       (it "should not emit anything at the end of other suites"
-        (buttercup-reporter-batch 'suite-done child-suite)
+        (with-local-buttercup :color nil
+          (buttercup-reporter-batch 'suite-done child-suite))
         (expect (buttercup-output) :to-equal-including-properties ""))
 
       (it "should not color-print anything at the end of other suites"
-        (buttercup-reporter-batch-color 'suite-done child-suite)
+        (with-local-buttercup :color t
+          (buttercup-reporter-batch-color 'suite-done child-suite))
         (expect (buttercup-output) :to-equal-including-properties "")))
 
     (describe "on the buttercup-done event"
@@ -1267,13 +1280,13 @@ text properties using `ansi-color-apply'."
 
       (it "should print a summary of run and failing specs"
         (setq failed-specs 6)
-        (let (buttercup-reporter-batch--failures)
+        (with-local-buttercup :color nil
           (buttercup-reporter-batch 'buttercup-done nil))
         (expect (buttercup-output) :to-match
                 "Ran 10 specs, 6 failed, in [0-9]+.[0-9]+[mu]?s.\n"))
 
       (it "should color-print `0 failed' specs in green"
-        (let (buttercup-reporter-batch--failures)
+        (with-local-buttercup :color t
           (buttercup-reporter-batch-color 'buttercup-done nil))
         (expect (buttercup-output) :to-match
                 "Ran 10 specs, 0 failed, in [0-9]+.[0-9]+[mu]?s.\n")
@@ -1283,7 +1296,7 @@ text properties using `ansi-color-apply'."
 
       (it "should color-print `X failed' specs in red"
         (setq failed-specs 6)
-        (let (buttercup-reporter-batch--failures)
+        (with-local-buttercup :color t
           (buttercup-reporter-batch-color 'buttercup-done nil))
         (expect (buttercup-output) :to-match
                 "Ran 10 specs, 6 failed, in [0-9]+.[0-9]+[mu]?s.\n")
@@ -1293,15 +1306,15 @@ text properties using `ansi-color-apply'."
 
       (it "should print a summary separating run and pending specs"
         (setq pending-specs 3)
-        (let (buttercup-reporter-batch--failures)
+        (with-local-buttercup :color nil
           (buttercup-reporter-batch 'buttercup-done nil))
         (expect (buttercup-output) :to-match
                 "Ran 7 out of 10 specs, 0 failed, in [0-9]+.[0-9]+[mu]?s.\n"))
 
       (it "should color-print pending spec count in default color"
         (setq pending-specs 3)
-        (let (buttercup-reporter-batch--failures)
-          (buttercup-reporter-batch 'buttercup-done nil))
+        (with-local-buttercup :color t
+          (buttercup-reporter-batch-color 'buttercup-done nil))
         (expect (buttercup-output) :to-match
                 "Ran 7 out of 10 specs, 0 failed, in [0-9]+.[0-9]+[mu]?s.\n")
         (expect (substring (buttercup-output)
@@ -1311,7 +1324,7 @@ text properties using `ansi-color-apply'."
 
       (it "should not raise any error even if a spec failed"
         (setf (buttercup-spec-status spec) 'failed)
-        (let (buttercup-reporter-batch--failures)
+        (with-local-buttercup :color nil
           (expect (buttercup-reporter-batch 'buttercup-done (list spec))
                   :not :to-throw)))
       ;; TODO: Backtrace tests

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1292,7 +1292,7 @@ text properties using `ansi-color-apply'."
                 "Ran 10 specs, 0 failed, in [0-9]+.[0-9]+[mu]?s.\n")
         (expect (substring (buttercup-output) 0 (length "Ran 10 specs, 0 failed, in"))
                 :to-equal-including-properties
-                (ansi-color-apply "Ran 10 specs,\e[32m 0 failed\e[0m, in")))
+                (ansi-color-apply "Ran 10 specs, \e[32m0 failed\e[0m, in")))
 
       (it "should color-print `X failed' specs in red"
         (setq failed-specs 6)
@@ -1302,7 +1302,7 @@ text properties using `ansi-color-apply'."
                 "Ran 10 specs, 6 failed, in [0-9]+.[0-9]+[mu]?s.\n")
         (expect (substring (buttercup-output) 0 (length "Ran 10 specs, 6 failed, in"))
                 :to-equal-including-properties
-                (ansi-color-apply "Ran 10 specs,\e[31m 6 failed\e[0m, in")))
+                (ansi-color-apply "Ran 10 specs, \e[31m6 failed\e[0m, in")))
 
       (it "should print a summary separating run and pending specs"
         (setq pending-specs 3)

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1115,7 +1115,7 @@ text properties using `ansi-color-apply'."
 
       (it "should color-print the number of specs with the default color"
         (with-local-buttercup :color t
-          (buttercup-reporter-batch-color 'buttercup-started (list parent-suite)))
+          (buttercup-reporter-batch 'buttercup-started (list parent-suite)))
         (expect (buttercup-output) :to-equal-including-properties "Running 1 specs.\n\n"))
 
       (it "should print the number of skipped specs"
@@ -1127,7 +1127,7 @@ text properties using `ansi-color-apply'."
       (it "should color-print the number of skipped specs with the default color"
         (with-local-buttercup :color t
           (buttercup-suite-add-child child-suite skipped)
-          (buttercup-reporter-batch-color 'buttercup-started (list parent-suite)))
+          (buttercup-reporter-batch 'buttercup-started (list parent-suite)))
         (expect (buttercup-output) :to-equal-including-properties "Running 1 out of 2 specs.\n\n")))
 
     (describe "on the suite-started event"
@@ -1138,7 +1138,7 @@ text properties using `ansi-color-apply'."
 
       (it "should color-print an indented suite description with the default color"
         (with-local-buttercup :color t
-         (buttercup-reporter-batch-color 'suite-started child-suite))
+         (buttercup-reporter-batch 'suite-started child-suite))
         (expect (buttercup-output) :to-equal-including-properties "  child-suite\n")))
 
     (describe "on the spec-started event"
@@ -1149,7 +1149,7 @@ text properties using `ansi-color-apply'."
 
       (it "should color-print an indented spec description with the default color"
         (with-local-buttercup :color t
-         (buttercup-reporter-batch-color 'spec-started spec))
+         (buttercup-reporter-batch 'spec-started spec))
         (expect (buttercup-output) :to-equal-including-properties "    spec")))
 
     (describe "on the spec-done event"
@@ -1169,8 +1169,8 @@ text properties using `ansi-color-apply'."
 
         (it "should color-print the description in green and no status tag"
           (with-local-buttercup :color t
-           (buttercup-reporter-batch-color 'spec-started spec)
-           (buttercup-reporter-batch-color 'spec-done spec))
+           (buttercup-reporter-batch 'spec-started spec)
+           (buttercup-reporter-batch 'spec-done spec))
           (expect (buttercup-output) :to-equal-including-properties
                   (ansi-color-apply
                    (format "\e[32m    spec\e[0m (%s)\n"
@@ -1188,8 +1188,8 @@ text properties using `ansi-color-apply'."
         (it "should color-print multiline specs cleanly"
           (setf (buttercup-spec-description spec) "one\ntwo\vthree")
           (with-local-buttercup :color t
-           (buttercup-reporter-batch-color 'spec-started spec)
-           (buttercup-reporter-batch-color 'spec-done spec))
+           (buttercup-reporter-batch 'spec-started spec)
+           (buttercup-reporter-batch 'spec-done spec))
           (expect (buttercup-output) :to-equal-including-properties
                   (ansi-color-apply
                    (format "\e[32m    one\ntwo\n   three\e[0m (%s)\n"
@@ -1211,8 +1211,8 @@ text properties using `ansi-color-apply'."
 
         (it "should color-print the description in red and say FAILED"
           (with-local-buttercup :color t
-            (buttercup-reporter-batch-color 'spec-started spec)
-            (buttercup-reporter-batch-color 'spec-done spec))
+            (buttercup-reporter-batch 'spec-started spec)
+            (buttercup-reporter-batch 'spec-done spec))
           (expect (buttercup-output) :to-equal-including-properties
                   (ansi-color-apply
                    (format "\e[31m    spec  FAILED\e[0m (%s)\n"
@@ -1235,8 +1235,8 @@ text properties using `ansi-color-apply'."
 
         (it "should color-print the description and failure-description in yellow"
           (with-local-buttercup :color t
-            (buttercup-reporter-batch-color 'spec-started spec)
-            (buttercup-reporter-batch-color 'spec-done spec))
+            (buttercup-reporter-batch 'spec-started spec)
+            (buttercup-reporter-batch 'spec-done spec))
           (expect (buttercup-output) :to-equal-including-properties
                   (ansi-color-apply
                    (format "\e[33m    spec  DESCRIPTION\e[0m (%s)\n"
@@ -1261,7 +1261,7 @@ text properties using `ansi-color-apply'."
 
       (it "should color-print a newline at the end of a top-level suite"
         (with-local-buttercup :color t
-         (buttercup-reporter-batch-color 'suite-done parent-suite))
+         (buttercup-reporter-batch 'suite-done parent-suite))
         (expect (buttercup-output) :to-equal-including-properties "\n"))
 
       (it "should not emit anything at the end of other suites"
@@ -1271,7 +1271,7 @@ text properties using `ansi-color-apply'."
 
       (it "should not color-print anything at the end of other suites"
         (with-local-buttercup :color t
-          (buttercup-reporter-batch-color 'suite-done child-suite))
+          (buttercup-reporter-batch 'suite-done child-suite))
         (expect (buttercup-output) :to-equal-including-properties "")))
 
     (describe "on the buttercup-done event"
@@ -1293,7 +1293,7 @@ text properties using `ansi-color-apply'."
 
       (it "should color-print `0 failed' specs in green"
         (with-local-buttercup :color t
-          (buttercup-reporter-batch-color 'buttercup-done nil))
+          (buttercup-reporter-batch 'buttercup-done nil))
         (expect (buttercup-output) :to-match
                 "Ran 10 specs, 0 failed, in [0-9]+.[0-9]+[mu]?s.\n")
         (expect (substring (buttercup-output) 0 (length "Ran 10 specs, 0 failed, in"))
@@ -1303,7 +1303,7 @@ text properties using `ansi-color-apply'."
       (it "should color-print `X failed' specs in red"
         (setq failed-specs 6)
         (with-local-buttercup :color t
-          (buttercup-reporter-batch-color 'buttercup-done nil))
+          (buttercup-reporter-batch 'buttercup-done nil))
         (expect (buttercup-output) :to-match
                 "Ran 10 specs, 6 failed, in [0-9]+.[0-9]+[mu]?s.\n")
         (expect (substring (buttercup-output) 0 (length "Ran 10 specs, 6 failed, in"))
@@ -1320,7 +1320,7 @@ text properties using `ansi-color-apply'."
       (it "should color-print pending spec count in default color"
         (setq pending-specs 3)
         (with-local-buttercup :color t
-          (buttercup-reporter-batch-color 'buttercup-done nil))
+          (buttercup-reporter-batch 'buttercup-done nil))
         (expect (buttercup-output) :to-match
                 "Ran 7 out of 10 specs, 0 failed, in [0-9]+.[0-9]+[mu]?s.\n")
         (expect (substring (buttercup-output)


### PR DESCRIPTION
Some pieces - typically code that was duplicated between the two batch
reporters - have been split out into separate functions.

This simplifies the maintenance of the batch reporter code and enables
future features such as #161.


----

#