### PR TITLE
Optionally fail when loading old elc files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: test
 test: test-buttercup test-docs
 
 test-buttercup: compile
-	./bin/buttercup -L . tests
+	./bin/buttercup -L . tests $(if $(CI),--traceback pretty)
 
 test-docs: compile
 	$(EMACS) -batch -L . -l buttercup.el -f buttercup-run-markdown docs/writing-tests.md

--- a/bin/buttercup
+++ b/bin/buttercup
@@ -56,6 +56,8 @@ Buttercup options:
                           frame with a lambda or M to indicate whether
                           it is a normal function call or a
                           macro/special form.
+
+--stale-file-error      Fail the test run if stale .elc files are loaded.
 EOF
 }
 
@@ -81,7 +83,7 @@ do
             shift
             shift
             ;;
-        "-c"|"--no-color"|"--no-skip"|"--only-error")
+        "-c"|"--no-color"|"--no-skip"|"--only-error"|"--stale-file-error")
             BUTTERCUP_ARGS+=("$1")
             shift
             ;;
@@ -100,3 +102,7 @@ done
 
 # `--' is needed so that Buttercup options don't get parsed by Emacs itself.
 exec "$EMACS_BIN" -batch "${EMACS_ARGS[@]}" -l buttercup -f buttercup-run-discover -- "${BUTTERCUP_ARGS[@]}"
+
+# Local Variables:
+# indent-tabs-mode: nil
+# End:

--- a/buttercup-compat.el
+++ b/buttercup-compat.el
@@ -109,6 +109,17 @@ If INCLUDE-DIRECTORIES, also include directories that have matching names."
                            (<= (car here) delay)))
                (concat (format "%.2f" (/ delay (car (cddr here)))) (cadr here)))))))
 
+;;;;;;;;;;;;;;;;;;;;;
+;; Introduced in 26.1
+
+(unless (fboundp 'file-attribute-modification-time)
+  (defsubst file-attribute-modification-time (attributes)
+	"The modification time in ATTRIBUTES returned by `file-attributes'.
+This is the time of the last change to the file's contents, and
+is a Lisp timestamp in the style of `current-time'."
+	(nth 5 attributes)))
+
+
 
 (provide 'buttercup-compat)
 ;;; buttercup-compat.el ends here


### PR DESCRIPTION
The new --stale-file-error option can be used to activate a hook that
will signal an error if a stale .elc file is loaded.  Stale means
older than its originating .el file.

Fixes #142.