### PR TITLE
Print sparse batch reports

### DIFF
--- a/bin/buttercup
+++ b/bin/buttercup
@@ -34,6 +34,14 @@ Buttercup options:
                           description (the concatenation of the test
                           and all paremt suites descriptions).
 
+--no-skip               Do not print the descriptions for tests that
+                          are filtered out with "--pattern" or disabled
+                          with "xit". Tests skipped wiath "assume" will
+                          still be priuted,
+
+--only-error            Only print failed tests and their containing suites.
+                          Implies "--no-skip".
+
 --no-color, -c          Do not colorize test output.
 
 --traceback STYLE       When printing backtraces for errors that occur
@@ -73,7 +81,7 @@ do
             shift
             shift
             ;;
-        "-c"|"--no-color")
+        "-c"|"--no-color"|"--no-skip"|"--only-error")
             BUTTERCUP_ARGS+=("$1")
             shift
             ;;
@@ -90,4 +98,5 @@ do
     esac
 done
 
-exec "$EMACS_BIN" -batch "${EMACS_ARGS[@]}" -l buttercup -f buttercup-run-discover "${BUTTERCUP_ARGS[@]}"
+# `--' is needed so that Buttercup options don't get parsed by Emacs itself.
+exec "$EMACS_BIN" -batch "${EMACS_ARGS[@]}" -l buttercup -f buttercup-run-discover -- "${BUTTERCUP_ARGS[@]}"

--- a/buttercup.el
+++ b/buttercup.el
@@ -1707,7 +1707,7 @@ Colorize parts of the output if COLOR is non-nil."
                             (buttercup-colorize "FAILED" 'red)
                           "FAILED")
                         description))
-     ((eq (car description) 'error)
+     ((and (consp description) (eq (car description) 'error))
       (buttercup--print "%S: %S\n\n"
                         (car description)
                         (cadr description)))

--- a/docs/running-tests.md
+++ b/docs/running-tests.md
@@ -30,7 +30,7 @@ feature/feature.el
 
 **feature.el**
 
-```Lisp
+```Emacs-Lisp
 (defun featurize (bug feature)
   (format "It's not a %s, it's a %s" bug feature))
 
@@ -100,7 +100,8 @@ named `test-*.el`, `*-test.el` or `*-tests.el`.
 Use the `--pattern PATTERN` option to only Only run tests with names
 matching PATTERN. The `--pattern` option can be used multiple times,
 in which case tests will be run if they match any of the given
-patterns.
+patterns. Combine with the `--no-skip` option to filter out the
+skipped tests.
 
 You can run this command whichever way you like. Common choices
 include a makefile or shell scripts.


### PR DESCRIPTION
Extend batch reporters to optionally print sparse reports

By adding any of the statuses `passed`, `pending`, `skipped`, `disabled` or `failed` to the variable `buttercup-reporter-batch-quiet-statuses`, any specs with that status will not be listed by the batch reporter.

Any suite that only contains such quieted spec will not be printed either.  Suites containing no specs also wont be printed if any status is listed in `buttercup-reporter-batch-quiet-statuses`.

Add new options `--no-skip` and `--only-error` to `bin/buttercup` for two common combinations of silenced statuses.