### PR TITLE
Fix compilation warning about undefined variable.

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -1338,6 +1338,9 @@ or a macro/special form.")
 A buffer with this name should only exist while running a test
 spec, and should be killed after running the spec.")
 
+(defvar buttercup-reporter-batch-quiet-statuses nil
+  "Do not print results for any spec with any of the listed statuses.")
+
 ;;;###autoload
 (defun buttercup-run-at-point ()
   "Run the buttercup suite at point."
@@ -1618,9 +1621,6 @@ EVENT and ARG are described in `buttercup-reporter'."
 
 (defvar buttercup-reporter-batch--failures nil
   "List of failed specs of the current batch report.")
-
-(defvar buttercup-reporter-batch-quiet-statuses nil
-  "Do not print results for any spec with any of the listed statuses.")
 
 (defvar buttercup-reporter-batch--suite-stack nil
   "Stack of unprinted suites.")


### PR DESCRIPTION
Dynamic variables always need to be defined before use.