### PR TITLE
Print args as sexp for consistency

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -643,10 +643,10 @@ See also `buttercup-define-matcher'."
     (cond
      ((not calls)
       (cons nil
-            (format "Expected `%s' to have been called with %s, but it was not called at all" spy args)))
+            (format "Expected `%s' to have been called with %S, but it was not called at all" spy args)))
      ((not (member args calls))
       (cons nil
-            (format "Expected `%s' to have been called with %s, but it was called with %s"
+            (format "Expected `%s' to have been called with %S, but it was called with %s"
                     spy
                     args
                     (mapconcat (lambda (args)


### PR DESCRIPTION
I'm currently figuring out a failing test using `:to-have-been-called-with` and for some reason it prints only one side of the args as sexp and the other as string.  This makes comparing the expected with the actual hard for no reason.