### PR TITLE
Make formatting of backtrace frames closer to that standard for Emacs

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -1982,7 +1982,10 @@ If STYLE is nil, use `buttercup-stack-frame-style' or `crop'."
   (setq style (or style buttercup-stack-frame-style 'crop))
   (pcase style
     (`omit) ; needed to verify valid styles
-    (`full (format "  %S" (cdr frame)))
+    (`full
+     (if (car frame)
+         (format "  %S%s" (cadr frame) (if (cddr frame) (prin1-to-string (cddr frame)) "()"))
+       (format "  %S" (cdr frame))))
     (`crop
      (let ((line (buttercup--format-stack-frame frame 'full)))
        ;; Note: this could be done sith `s-truncate' from the s

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1459,7 +1459,7 @@ text properties using `ansi-color-apply'."
        :suites test-suites :reporter #'backtrace-reporter
        :frame-style 'crop
        (buttercup-run :noerror)
-       (setq long-string (truncate-string-to-width long-string 62))
+       (setq long-string (truncate-string-to-width long-string 63))
        (expect (buttercup-output) :to-match
                (rx-to-string
                 `(seq
@@ -1468,9 +1468,9 @@ text properties using `ansi-color-apply'."
                   "suite bc-bt-backtrace\n"
                   "\n"
                   "Traceback (most recent call last):\n"
-                  "  (bc-bt-foo \"" (eval ,long-string) "...\n"
-                  "  (bc-bt-bar \"" (eval ,long-string) "...\n"
-                  "  (bc-bt-baz \"" (eval ,long-string) "...\n"
+                  "  bc-bt-foo(\"" (eval ,long-string) "...\n"
+                  "  bc-bt-bar(\"" (eval ,long-string) "...\n"
+                  "  bc-bt-baz(\"" (eval ,long-string) "...\n"
                   (* (seq "  " (or (seq (= 74 not-newline) (= 3 ?.))
                                    (seq (** 0 74 not-newline) (= 3 (not (any ?.))))) "\n"))
                   "error: (" (* anything) ")\n\n"
@@ -1488,9 +1488,9 @@ text properties using `ansi-color-apply'."
                   "suite bc-bt-backtrace\n"
                   "\n"
                   "Traceback (most recent call last):\n"
-                  "  (bc-bt-foo \"" (eval ,long-string) "\")\n"
-                  "  (bc-bt-bar \"" (eval ,long-string) "\")\n"
-                  "  (bc-bt-baz \"" (eval ,long-string) "\")\n"
+                  "  bc-bt-foo(\"" (eval ,long-string) "\")\n"
+                  "  bc-bt-bar(\"" (eval ,long-string) "\")\n"
+                  "  bc-bt-baz(\"" (eval ,long-string) "\")\n"
                   (* (seq "  " (* not-newline) (= 3 (not (any ?.))) "\n"))
                   "error: (" (* anything) ")\n\n"
                   string-end)))))
@@ -1543,13 +1543,13 @@ text properties using `ansi-color-apply'."
                           "backtrace for matcher"
                           ""
                           "Traceback (most recent call last):"
-                          "  (bc-bt-baz \"text\")"
+                          "  bc-bt-baz(\"text\")"
                           ,(concat
                             "  (or (number-or-marker-p a) (signal "
                             (if (< emacs-major-version 27)
                                 "(quote wrong-type-argument) (list (quot..."
                                "'wrong-type-argument (list 'number-or-m..."))
-                          "  (signal wrong-type-argument (number-or-marker-p \"text\"))"
+                          "  signal(wrong-type-argument (number-or-marker-p \"text\"))"
                           "error: (wrong-type-argument number-or-marker-p \"text\")"
                           "" "") "\n"))))))
       (matcher-spec "no matcher")


### PR DESCRIPTION
With the following test:

    (it "fails"
        (let ((x (lambda () (backtrace) xxx)))
          (funcall x)))

Buttercup currently produces the following backtrace:

    Traceback (most recent call last):
      (let ((x #'(lambda nil (backtrace) xxx))) (funcall x))
      (funcall (lambda nil (backtrace) xxx))
      ((lambda nil (backtrace) xxx))
    error: (void-variable xxx)

You can compare this with `(backtrace)` output (also in the test):

      backtrace()
      (lambda nil (backtrace) xxx)()
      funcall((lambda nil (backtrace) xxx))
      (let ((x #'(lambda nil (backtrace) xxx))) (funcall x))

You can see that standard Emacs backtrace prints `funcall` *outside* the parens. With the proposed changes so does Buttercup:

    Traceback (most recent call last):
      (let ((x #'(lambda nil (backtrace) xxx))) (funcall x))
      funcall((lambda nil (backtrace) xxx))
      (lambda nil (backtrace) xxx)()
    error: (void-variable xxx)

There is no need to create additional tests for the change, it gets caught by the existing tests already. So, I modified those that started failing (i.e. they asserted previous formatting, I changed them to assert the new formatting that is closer to what Emacs itself does).