### PR TITLE
Use an absolute path for the root of test files

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -1408,7 +1408,7 @@ current directory."
         (push (car args) dirs)
         (setq args (cdr args)))))
     (setq command-line-args-left nil)
-    (dolist (dir (or dirs '(".")))
+    (dolist (dir (or dirs (list default-directory)))
       (dolist (file (directory-files-recursively
                      dir "\\`test-.*\\.el\\'\\|-tests?\\.el\\'"))
         ;; Exclude any hidden directory, both immediate (^.) and nested (/.) subdirs


### PR DESCRIPTION
When I ran `buttercup-run-discover`, I encountered the following error:

> Cannot open load file: No such file or directory, ./org-multi-wiki-tests.el

It seems that `load` function sometimes (?) fails to load a file starting with `./`. For example, it fails when I run `buttercup-run-discover .` from the command line, while it succeeds when running `buttercup-run-discover $PWD`. I find it strange, but it would be safer to use `default-directory`.