### PR TITLE
Do not store backtraces for pending specs

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -1938,7 +1938,10 @@ ARGS according to `debugger'."
   ;; subsequent calls. Thanks to ert for this.
   (setq num-nonmacro-input-events (1+ num-nonmacro-input-events))
   (throw 'buttercup-debugger-continue
-         (list 'failed args (buttercup--backtrace))))
+         (list 'failed args
+               (cl-destructuring-bind (_ (signal-type . _data)) args
+                 (unless (eq signal-type 'buttercup-pending)
+                   (buttercup--backtrace))))))
 
 (defalias 'buttercup--mark-stackframe 'ignore
   "Marker to find where the backtrace start.")

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1585,7 +1585,18 @@ text properties using `ansi-color-apply'."
       (matcher-spec ":to-have-been-called-with" :to-have-been-called-with 2)
       (matcher-spec ":not :to-have-been-called-with" :not :to-have-been-called-with 2)
       (matcher-spec ":to-have-been-called-times" :to-have-been-called-times 2)
-      (matcher-spec ":not :to-have-been-called-times" :not :to-have-been-called-times 2))))
+      (matcher-spec ":not :to-have-been-called-times" :not :to-have-been-called-times 2)))
+  (it "should not generate backtraces for skipped specs"
+    (let (test-spec)
+      (spy-on 'buttercup--backtrace :and-call-through)
+      (with-local-buttercup
+        (describe "one description"
+          (it "with a pending spec")
+          (buttercup-skip "skip"))
+        (buttercup-run :noerror)
+        (setq test-spec (car (buttercup-suite-children (car buttercup-suites)))))
+      (expect 'buttercup--backtrace :not :to-have-been-called)
+      (expect (buttercup-spec-failure-stack test-spec) :to-be nil))))
 
 
 (describe "When using quiet specs in the batch reporter"


### PR DESCRIPTION
Only call buttercup--backtrace when the signal is not
buttercup-pending.

Fixes #205.