### PR TITLE
Avoid a compilation warning.

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -1939,7 +1939,7 @@ ARGS according to `debugger'."
   (setq num-nonmacro-input-events (1+ num-nonmacro-input-events))
   (throw 'buttercup-debugger-continue
          (list 'failed args
-               (cl-destructuring-bind (_ (signal-type . _data)) args
+               (cl-destructuring-bind (_ (signal-type . data)) args
                  (unless (eq signal-type 'buttercup-pending)
                    (buttercup--backtrace))))))
 


### PR DESCRIPTION
Currently, compilation prints a warning:

    In toplevel form:
    buttercup.el:1933:1: Warning: variable ‘_data’ not left unused

The warning is incorrect (see
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=26960), but I think it’s better
to avoid the warning so that the file compiles cleanly.