### PR TITLE
Collect backtraces for failed test file loads and display them as failed specs

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -48,6 +48,9 @@
 (require 'ert nil t)
 (require 'warnings)
 
+;; A base error for all errors raised by buttercup.
+(define-error 'buttercup-error-base "error")
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; wrapper function manipulation
 
@@ -116,11 +119,9 @@ a call to `save-match-data', as `format-spec' modifies that."
 ;;;;;;;;;;
 ;;; expect
 
-(define-error 'buttercup-failed
-  "Buttercup test failed")
+(define-error 'buttercup-failed "Buttercup test failed" 'buttercup-error-base)
 
-(define-error 'buttercup-pending
-  "Buttercup test is pending")
+(define-error 'buttercup-pending "Buttercup test is pending" 'buttercup-error-base)
 
 (defmacro expect (arg &optional matcher &rest args)
   "Expect a condition to be true.
@@ -1510,6 +1511,8 @@ have been defined."
     (or (and noerror :no-suites)
         (error "No suites defined"))))
 
+(define-error 'buttercup-run-specs-failed "buttercup-run failed" 'buttercup-error-base)
+
 (defun buttercup--run-suites (suites &optional noerror)
   "Run a list of SUITES.
 Signal an error if any spec fail. Signal no error if NOERROR is
@@ -1519,7 +1522,7 @@ fail."
   (mapc #'buttercup--run-suite suites)
   (funcall buttercup-reporter 'buttercup-done suites)
   (or (zerop (buttercup-suites-total-specs-failed suites))
-      (not (or noerror (error "")))))
+      (not (or noerror (signal 'buttercup-run-specs-failed '(""))))))
 
 (defvar buttercup--before-each nil
   "A list of functions to call before each spec.

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1959,6 +1959,26 @@ text properties using `ansi-color-apply'."
           (expect loaded-files :to-have-same-items-as '("a/a-tests.el"
                                                         "a/b/ab-tests.el")))))))
 
+;; The nested debuggers of running buttercup specs inside other
+;; buttercup specs does not do the right thing. Write out-of-framework
+;; tests for now.
+
+(buttercup--test-with-tempdir
+  '("ok-test.el"
+    ("test-a.el" "(describe \"foo\"")
+    ("test-b.el" "(describe \"bar\" (it \"baz\" (ignore)))"))
+  (let ((load-path (cons default-directory load-path))
+        buttercup-status-error-caught)
+    (with-local-buttercup
+      (condition-case condition
+          (buttercup-run-discover)
+        (buttercup-run-specs-failed (setq buttercup-status-error-caught t)))
+      (unless buttercup-status-error-caught
+        (error "Expected buttercup-run-discover to signal a buttercup-run-specs-failed error"))
+      (unless (equal 2 (length buttercup-suites))
+        (error "Expected suites from test-b.el to be in buttercup-suites"))
+      )))
+
 ;;;;;;;;;;;;;
 ;;; Utilities
 

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1727,7 +1727,7 @@ text properties using `ansi-color-apply'."
   (it "should raise an error if at least one spec failed"
     (setf (buttercup-spec-status spec) 'failed)
     (with-local-buttercup :suites (list parent-suite)
-      (expect (buttercup-run) :to-throw 'error '(""))))
+      (expect (buttercup-run) :to-throw 'buttercup-run-specs-failed '(""))))
   (it "should return nil for failing specs and noerror"
     (setf (buttercup-spec-status spec) 'failed)
     (with-local-buttercup :suites (list parent-suite)


### PR DESCRIPTION
Use the existing error catching and backtrace collecting infrastructure when loading test files.  
For each test file that signals an error while loading, add a pre-failed spec to a special suite, and add that suite to the end of `buttercup-suites`.  These load failures will be listed at the end of the test report.
buttercup will still process any fully loaded specs, including spec from a partially loaded test file. 
The total buttercup run will fail as there are failing specs, and failure will be included in any test report even if the reporter does not print to stdout, like `buttercup-junit`.

Fixes #107 