### PR TITLE
Add spy-arg-matcher for more complex matching of spy arguments

### DIFF
--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -422,6 +422,34 @@ the argument list matches any of the recorded calls to the spy.
     (expect bar :to-be nil)))
 ```
 
+The `:to-have-been-called-with` matcher can also take special
+`spy-arg-matcher` arguments to perform more complex tests of the
+argument.  For example, if you only care about the second argument to
+the function call you might want to express "first argument can be
+anything".  This can be achieved with `spy-arg-matcher-any`:
+
+``` Emacs-Lisp
+(it "second argument matches :keyword"
+  (spy-on 'bar)
+  (bar "anything" :keyword)
+  (expect 'bar :to-have-been-called-with (spy-arg-matcher-any) :keyword))
+```
+
+Other built in matcher is `(spy-arg-matcher-any-of list)` witch
+matches if argument is `equal` to any of the elements of `list`.
+Finally, you can construct your own custom matcher by passing a single
+argument lambda to `(spy-arg-matcher pred)` to use that predicate to
+test the argument:
+
+``` Emacs-Lisp
+(cl-defstruct person name)
+
+(it "was called with a person struct"
+  (spy-on 'bar)
+  (bar (person :name "XYZ"))
+  (expect 'bar :to-have-been-called-with (spy-arg-matcher #'person-p)))
+```
+
 The `:to-have-been-called-times` matcher will return true if the spy
 was called a certain number of times.
 

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1414,7 +1414,59 @@ text properties using `ansi-color-apply'."
                  :to-have-been-called-with
                  (mapcar #'buttercup--wrap-expr '('test-function 1 2 3)))
                 :to-be
-                t)))
+                t))
+
+      (describe "spy-arg-matcher"
+
+        (it "returns true for any argument passed to spy-arg-matcher-any"
+          (test-function 1)
+          (expect (buttercup--apply-matcher
+                   :to-have-been-called-with
+                   (mapcar #'buttercup--wrap-expr
+                           '('test-function
+                             (spy-arg-matcher-any))))
+                  :to-be
+                  t))
+
+        (it "returns true if argument matches some of the spy-arg-matcher-any-of"
+          (test-function 1)
+          (expect (buttercup--apply-matcher
+                   :to-have-been-called-with
+                   (mapcar #'buttercup--wrap-expr
+                           '('test-function
+                             (spy-arg-matcher-any-of (list 4 3 1 2)))))
+                  :to-be
+                  t))
+
+        (it "returns false if argument matches none of the spy-arg-matcher-any-of"
+          (test-function 1)
+          (expect (car (buttercup--apply-matcher
+                        :to-have-been-called-with
+                        (mapcar #'buttercup--wrap-expr
+                                '('test-function
+                                  (spy-arg-matcher-any-of (list 4 3 2))))))
+                  :to-be
+                  nil))
+
+        (it "returns true if argument matches custom predicate"
+          (test-function 1)
+          (expect (buttercup--apply-matcher
+                   :to-have-been-called-with
+                   (mapcar #'buttercup--wrap-expr
+                           '('test-function
+                             (spy-arg-matcher (lambda (x) (= x 1))))))
+                  :to-be
+                  t))
+
+        (it "returns false if argument does not match custom predicate"
+          (test-function 1)
+          (expect (car (buttercup--apply-matcher
+                        :to-have-been-called-with
+                        (mapcar #'buttercup--wrap-expr
+                                '('test-function
+                                  (spy-arg-matcher (lambda (x) (= x 2)))))))
+                  :to-be
+                  nil))))
 
     (describe ":to-have-been-called-times matcher"
       (before-each


### PR DESCRIPTION
More matchers to add for inspiration for example from Mockery: http://docs.mockery.io/en/latest/reference/argument_validation.html?highlight=matchers#additional-argument-matchers