### PR TITLE
test: Change `pretty' test regexp to pass tests on emacs 30.

### DIFF
--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -2009,9 +2009,15 @@ text properties using `ansi-color-apply'."
                   "suite bc-bt-backtrace\n"
                   "\n"
                   "Traceback (most recent call last):\n"
-                  "λ (bc-bt-foo \"" (regex ,long-string) "\")\n"
-                  "λ (bc-bt-bar \"" (regex ,long-string) "\")\n"
-                  "λ (bc-bt-baz \"" (regex ,long-string) "\")\n"
+                  (seq
+                   "λ (bc-bt-foo \"" (regex ,long-string) "\")"
+                   (optional "\n"))
+                  (seq
+                   "λ (bc-bt-bar \"" (regex ,long-string) "\")"
+                   (optional "\n"))
+                  (seq
+                   "λ (bc-bt-baz \"" (regex ,long-string) "\")"
+                   (optional "\n"))
                   (* (seq (or ?M ?λ) " (" (* not-newline) ; frame start
                           (*? (seq "\n   " (* not-newline))) ; any number of pp lines
                           (* not-newline) ")\n")) ;; frame end


### PR DESCRIPTION
This is a regexp change that should match test native compilation on both emacs 29 and emacs 30. Should fix https://github.com/jorgenschaefer/emacs-buttercup/issues/238. 