### PR TITLE
Improve backtrace looks and performance

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -83,8 +83,8 @@ For Emacs < 29:
 The function MUST be byte-compiled or have one of the following
 forms:
 
-\(closure (ENVLIST) () (quote EXPR) (buttercup--mark-stackframe) EXPANDED)
-\(lambda () (quote EXPR) (buttercup--mark-stackframe) EXPR)
+\(closure (ENVLIST) () (quote EXPR) EXPANDED)
+\(lambda () (quote EXPR) EXPR)
 
 and the return value will be EXPR, unevaluated. The quoted EXPR
 is useful if EXPR is a macro call, in which case the `quote'
@@ -98,7 +98,7 @@ ensures access to the un-expanded form."
     ;; * the stackframe marker
     ;; * the macroexpanded original expression
     (`(closure ,(pred listp) nil
-        (quote ,expr) (buttercup--mark-stackframe) ,_expanded)
+        (quote ,expr) ,_expanded)
      expr)
     ;; This a when FUN has not been evaluated.
     ;; Why does that happen?
@@ -107,7 +107,7 @@ ensures access to the un-expanded form."
     ;; * the stackframe marker
     ;; * the expanded expression
     (`(lambda nil
-        (quote ,expr) (buttercup--mark-stackframe) ,_expanded)
+        (quote ,expr) ,_expanded)
      expr)
     ;; This is when FUN has been byte compiled, as when the entire
     ;; test file has been byte compiled. Check that it has an empty
@@ -188,11 +188,9 @@ Does not have the IGNORE-MISSING and SPLIT parameters."
   "Wrap EXPR in a `buttercup--thunk' to be used by `buttercup-expect'."
   (if (fboundp 'oclosure-lambda)        ;Emacs≥29
       `(oclosure-lambda (buttercup--thunk (expr ',expr)) ()
-         (buttercup--mark-stackframe)
          ,expr)
     `(lambda ()
        (quote ,expr)
-       (buttercup--mark-stackframe)
        ,expr)))
 
 (defmacro expect (arg &optional matcher &rest args)
@@ -1015,7 +1013,6 @@ most probably including one or more calls to `expect'."
       `(buttercup-it ,description
          (lambda ()
            (buttercup-with-converted-ert-signals
-             (buttercup--mark-stackframe)
              ,@body)))
     `(buttercup-xit ,description)))
 
@@ -2110,9 +2107,6 @@ ARGS according to `debugger'."
                  (cl-case signal-type
                    ((buttercup-pending buttercup-failed))
                    (otherwise (buttercup--backtrace)))))))
-
-(defalias 'buttercup--mark-stackframe #'ignore
-  "Marker to find where the backtrace start.")
 
 (defun buttercup--backtrace ()
   "Create a backtrace, a list of frames returned from `backtrace-frame'."

--- a/buttercup.el
+++ b/buttercup.el
@@ -2107,8 +2107,9 @@ ARGS according to `debugger'."
                ;; args is (error (signal . data) ....) where the tail
                ;; may be empty
                (cl-destructuring-bind (signal-type . data) (cl-second args)
-                 (unless (eq signal-type 'buttercup-pending)
-                   (buttercup--backtrace))))))
+                 (cl-case signal-type
+                   ((buttercup-pending buttercup-failed))
+                   (otherwise (buttercup--backtrace)))))))
 
 (defalias 'buttercup--mark-stackframe #'ignore
   "Marker to find where the backtrace start.")
@@ -2129,7 +2130,6 @@ ARGS according to `debugger'."
            ;; wrapped expressions of an expect.
            (buttercup--wrapper-fun-p (cadr frame))
            ;; TODO: error in `it' but outside `expect'
-           ;; TODO: matchers that do not match should not collect backtrace
            ;; TODO: What about an error in a matcher?
            ;; TODO: What about :to-throw?
            ;; TODO: What about signals in before and after blocks?

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -2009,6 +2009,24 @@ before it's processed by other functions."
       (expect (cl-every #'null
                         (mapcar #'buttercup-spec-failure-stack
                                 (buttercup-suite-children (car test-suites)))))
+      (expect (buttercup-output) :to-equal ""))
+    (it "skipped specs"
+      (with-local-buttercup
+       :reporter #'backtrace-reporter
+        (describe "one description with"
+          (it "one skipped spec"
+            (buttercup-skip "skip"))
+          (xit "one empty spec")
+          (it "one un-assumed spec"
+            (assume nil "A very unassuming spec")))
+        (buttercup-run :noerror)
+        (setq test-suites buttercup-suites))
+      (expect 'buttercup--backtrace :not :to-have-been-called)
+      ;; Checking both if buttercup--backtrace have been called and
+      ;; the failure-stack value might be overkill
+      (expect (cl-every #'null
+                        (mapcar #'buttercup-spec-failure-stack
+                                (buttercup-suite-children (car test-suites)))))
       (expect (buttercup-output) :to-equal "")))
   (describe "with style"
     :var (test-suites long-string)
@@ -2159,18 +2177,7 @@ before it's processed by other functions."
       (matcher-spec ":to-have-been-called-with" :to-have-been-called-with 2)
       (matcher-spec ":not :to-have-been-called-with" :not :to-have-been-called-with 2)
       (matcher-spec ":to-have-been-called-times" :to-have-been-called-times 2)
-      (matcher-spec ":not :to-have-been-called-times" :not :to-have-been-called-times 2)))
-  (it "should not generate backtraces for skipped specs"
-    (let (test-spec)
-      (spy-on 'buttercup--backtrace :and-call-through)
-      (with-local-buttercup
-        (describe "one description"
-          (it "with a pending spec")
-          (buttercup-skip "skip"))
-        (buttercup-run :noerror)
-        (setq test-spec (car (buttercup-suite-children (car buttercup-suites)))))
-      (expect 'buttercup--backtrace :not :to-have-been-called)
-      (expect (buttercup-spec-failure-stack test-spec) :to-be nil))))
+      (matcher-spec ":not :to-have-been-called-times" :not :to-have-been-called-times 2))))
 
 
 (describe "When using quiet specs in the batch reporter"

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -180,18 +180,18 @@ before it's processed by other functions."
               "Not testable on Emacs 30+, not relevant for Emacs 29+")
       (expect (buttercup--enclosed-expr
                (let ((_foo 1))
-                 (lambda () '(ignore) (buttercup--mark-stackframe) (ignore))))
+                 (lambda () '(ignore) (ignore))))
               :to-equal '(ignore)))
     (it "a lambda with expression copy?"
       ;; I suspect there is nothing to make sure that the quoted
       ;; expression matches the actual expression
       (expect (buttercup--enclosed-expr
-               '(lambda () (quote (ignore)) (buttercup--mark-stackframe) (ignore))))
+               '(lambda () (quote (ignore)) (ignore))))
       :to-equal '(ignore))
     (describe "byte compiled"
       (it "lambda objects"
         (expect (buttercup--enclosed-expr
-                 (byte-compile-sexp '(lambda () '(ignore) (buttercup--mark-stackframe) (ignore))))))
+                 (byte-compile-sexp '(lambda () '(ignore) (ignore))))))
       (it "wrapped expression"
         (assume (not (fboundp 'buttercup--thunk-p)) "Not with Oclosures")
         (expect (buttercup--enclosed-expr (byte-compile-sexp (buttercup--wrap-expr '(ignore))))))))
@@ -202,15 +202,15 @@ before it's processed by other functions."
        :to-throw 'buttercup-enclosed-expression-error))
     (it "on a closure with stackframe marker but no quoted expression"
       (expect
-       (buttercup--enclosed-expr (let ((_foo 1)) (lambda () (buttercup--mark-stackframe) (ignore))))
+       (buttercup--enclosed-expr (let ((_foo 1)) (lambda () (ignore))))
        :to-throw 'buttercup-enclosed-expression-error))
     (it "for multi-statement closures"
       (expect (buttercup--enclosed-expr
-               (lambda () '(+ 1 2) (buttercup--mark-stackframe) (+ 1 2) (ignore)))
+               (lambda () '(+ 1 2) (+ 1 2) (ignore)))
               :to-throw 'buttercup-enclosed-expression-error))
     (it "for closures with non-empty argument lists"
       (expect (buttercup--enclosed-expr
-               (lambda (foo) '(ignore foo) (buttercup--mark-stackframe) (ignore foo)))
+               (lambda (foo) '(ignore foo) (ignore foo)))
               :to-throw 'buttercup-enclosed-expression-error))
     (it "on simple lambda objects"
       (expect (buttercup--enclosed-expr
@@ -218,7 +218,7 @@ before it's processed by other functions."
               :to-throw))
     (it "on a lambda with stackframe marker but no quoted expression"
       (expect (buttercup--enclosed-expr
-               '(lambda () (buttercup--mark-stackframe) (ignore)))
+               '(lambda () (ignore)))
               :to-throw 'buttercup-enclosed-expression-error))
     (it "for multi-statement lambdas"
       (expect (buttercup--enclosed-expr
@@ -230,7 +230,7 @@ before it's processed by other functions."
               :to-throw 'buttercup-enclosed-expression-error))
     (it "on byte-compiled functions with arguments"
       (expect (buttercup--enclosed-expr
-               (byte-compile-sexp '(lambda (_a) '(ignore) (buttercup--mark-stackframe) (ignore))))
+               (byte-compile-sexp '(lambda (_a) '(ignore) (ignore))))
               :to-throw 'buttercup-enclosed-expression-error))))
 
 ;;;;;;;;;;
@@ -1121,7 +1121,6 @@ before it's processed by other functions."
             '(buttercup-it "description"
                (lambda ()
                  (buttercup-with-converted-ert-signals
-                   (buttercup--mark-stackframe)
                    body)))))
 
   (it "without argument should expand to xit."

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -2028,6 +2028,28 @@ before it's processed by other functions."
                         (mapcar #'buttercup-spec-failure-stack
                                 (buttercup-suite-children (car test-suites)))))
       (expect (buttercup-output) :to-equal "")))
+  (describe "should be collected for errors in"
+    (it "matchers"
+      (put :--failing-matcher 'buttercup-matcher
+           (lambda (&rest _) (/ 1 0)))
+      (with-local-buttercup
+       :reporter #'backtrace-reporter
+       (describe "One suite with"
+         (it "a bad matcher"
+           (expect 1 :--failing-matcher 1)))
+       (buttercup-run :no-error))
+      (put :--failing-matcher 'buttercup-matcher nil)
+      (expect (buttercup-output) :to-equal
+              (concat
+                (make-string 40 ?=) "\n"
+                "One suite with a bad matcher\n"
+                "\n"
+                "Traceback (most recent call last):\n"
+                "  :--failing-matcher(1 1)\n"
+                "  /(1 0)\n"
+                "error: (arith-error)\n\n"
+                )))
+    )
   (describe "with style"
     :var (test-suites long-string)
     ;; Set up tests to test


### PR DESCRIPTION
Make the backtrace prints better - less unwanted output - with a lot better performance.
Fixes #247 and #220.