### PR TITLE
Warn when :var is used with a special variable

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -964,9 +964,9 @@ mainly calls to `describe', `it' and `before-each'."
        when (special-variable-p var)
        do (display-warning
            'buttercup-describe
-           (concat "Possible erroneous use of special variable `"
-                   (symbol-name var)
-                   "' in :var(*) form")))
+           (format
+            "Possible erroneous use of special variable `%s' in :var(*) form"
+            var)))
       ;; Wrap new body in the appropriate let form
       (setq body
             `((,let-form-to-use


### PR DESCRIPTION
Buttercup's ":var" and ":var*" forms only support lexical variables, so using a special variable in these forms will almost certainly not do what the test author expects.

See #127.

Notably, `test/test-buttercup.el` now actually issues 2 warnings of this type for the variable `buttercup-reporter-batch--start-time`. I'm unsure if this is intentional, because the comments at those tests suggest something non-standard is happening due to the recursiveness of buttercup testing itself. However, I suspect it is not intentional, and that changes to `buttercup-reporter-batch--start-time` made by those tests are not being properly "quarantined".