### PR TITLE
Fix before-all failure/pending not propagating to child specs

### DIFF
--- a/buttercup.el
+++ b/buttercup.el
@@ -1701,16 +1701,38 @@ Do not change the global value.")
     (funcall buttercup-reporter 'suite-started suite)
     (dolist (f (buttercup-suite-before-all suite))
       (buttercup--update-with-funcall suite f))
-    (dolist (sub (buttercup-suite-children suite))
-      (cond
-       ((buttercup-suite-p sub)
-        (buttercup--run-suite sub))
-       ((buttercup-spec-p sub)
-        (buttercup--run-spec sub))))
+    ;; If before-all marked the suite as pending or failed,
+    ;; propagate to all children and skip running them.
+    (if (memq (buttercup-suite-or-spec-status suite) '(pending failed))
+        (buttercup--propagate-suite-status suite)
+      (dolist (sub (buttercup-suite-children suite))
+        (cond
+         ((buttercup-suite-p sub)
+          (buttercup--run-suite sub))
+         ((buttercup-spec-p sub)
+          (buttercup--run-spec sub)))))
     (dolist (f (buttercup-suite-after-all suite))
       (buttercup--update-with-funcall suite f))
     (buttercup--set-end-time suite)
     (funcall buttercup-reporter 'suite-done suite)))
+
+(defun buttercup--propagate-suite-status (suite)
+  "Propagate the status of SUITE to all its children recursively.
+Each child spec is reported as started and done so reporters can
+display them.  Nested suites are handled recursively."
+  (let ((status (buttercup-suite-or-spec-status suite))
+        (desc (buttercup-suite-or-spec-failure-description suite)))
+    (dolist (sub (buttercup-suite-children suite))
+      (setf (buttercup-suite-or-spec-status sub) status
+            (buttercup-suite-or-spec-failure-description sub) desc)
+      (cond
+       ((buttercup-spec-p sub)
+        (funcall buttercup-reporter 'spec-started sub)
+        (funcall buttercup-reporter 'spec-done sub))
+       ((buttercup-suite-p sub)
+        (funcall buttercup-reporter 'suite-started sub)
+        (buttercup--propagate-suite-status sub)
+        (funcall buttercup-reporter 'suite-done sub))))))
 
 (defun buttercup--run-spec (spec)
   "Run SPEC."

--- a/tests/test-buttercup.el
+++ b/tests/test-buttercup.el
@@ -1201,6 +1201,45 @@ before it's processed by other functions."
               :to-equal
               (list 23)))))
 
+(describe "before-all failure/pending propagation"
+  (it "marks child specs as pending when before-all signals buttercup-pending"
+    (with-local-buttercup
+      (let ((suite (describe "Suite with pending before-all"
+                     (before-all
+                       (signal 'buttercup-pending "not ready"))
+                     (it "spec one" (expect 1 :to-equal 1))
+                     (it "spec two" (expect 2 :to-equal 2)))))
+        (buttercup--run-suite suite)
+        (dolist (child (buttercup-suite-children suite))
+          (expect (buttercup-suite-or-spec-status child)
+                  :to-equal 'pending)))))
+
+  (it "marks child specs as failed when before-all errors"
+    (with-local-buttercup
+      (let ((suite (describe "Suite with failing before-all"
+                     (before-all
+                       (error "Setup failed"))
+                     (it "spec one" (expect 1 :to-equal 1)))))
+        (buttercup--run-suite suite)
+        (dolist (child (buttercup-suite-children suite))
+          (expect (buttercup-suite-or-spec-status child)
+                  :to-equal 'failed)))))
+
+  (it "propagates pending to nested suites"
+    (with-local-buttercup
+      (let ((suite (describe "Outer"
+                     (before-all
+                       (signal 'buttercup-pending "not ready"))
+                     (describe "Inner"
+                       (it "nested spec" (expect 1 :to-equal 1))))))
+        (buttercup--run-suite suite)
+        (let* ((inner (car (buttercup-suite-children suite)))
+               (spec (car (buttercup-suite-children inner))))
+          (expect (buttercup-suite-or-spec-status inner)
+                  :to-equal 'pending)
+          (expect (buttercup-suite-or-spec-status spec)
+                  :to-equal 'pending))))))
+
 (describe "The `after-all' macro"
   (it "expands to a function call"
     (expect (macroexpand '(after-all (+ 1 1)))


### PR DESCRIPTION
When a `before-all` function signals `buttercup-pending` or raises an error, the suite is correctly marked but child specs still run normally, overwriting their status to `passed`. This means `before-all` guards like:

```elisp
(describe "my tests"
  (before-all
    (unless some-condition
      (signal 'buttercup-pending "not available")))
  (it "does something" ...))
```

don't actually skip the specs — they run and potentially fail with unrelated errors.

This PR adds a check after `before-all` completes: if the suite is `pending` or `failed`, the status is propagated to all child specs and nested suites, and the children are skipped. `after-all` functions still run for cleanup.

Fixes #179